### PR TITLE
Bug corrections, feature harmonisation between wasm and standalone, documentation updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,11 @@ default = ["basic"]
 # wasm = ["dep:js-sys", "dep:wasm-bindgen", "dep:simple-error", "dep:console_error_panic_hook", "dep:wasm-bindgen-file-reader", "dep:seq_io", "dep:flate2", "dep:web-sys", "dep:getrandom"]
 wasm = ["js-sys", "wasm-bindgen", "simple-error", "console_error_panic_hook", "wasm-bindgen-file-reader", "seq_io", "flate2", "web-sys", "getrandom",
         "serde", "ahash", "num-traits", "log", "simple_logger", "clap", "regex", "rayon", "num_cpus", "nohash-hasher",
-        "stacker", "project-root", "petgraph", "bnum", "json", "argmin", "argmin-math", "libm"]
+        # "stacker", "project-root", "petgraph", "bnum", "json", "argmin", "argmin-math", "libm"]
+        "stacker", "project-root", "petgraph", "bnum", "json", "argmin", "argmin-math", "argmin-observer-slog", "libm"]
 basic = ["needletail", "serde", "ahash", "num-traits", "log", "simple_logger", "indicatif", "clap", "regex", "rayon", "num_cpus", "nohash-hasher",
-         "stacker", "plotters", "project-root", "petgraph", "bnum", "argmin", "argmin-math", "libm"]
+         # "stacker", "plotters", "project-root", "petgraph", "bnum", "argmin", "argmin-math", "libm"]
+         "stacker", "plotters", "project-root", "petgraph", "bnum", "argmin", "argmin-math", "argmin-observer-slog", "libm"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -57,8 +59,10 @@ flate2                   = {version = "1.0"   , optional = true}
 getrandom                = {version = "0.2"   , optional = true, features = ["js"]}
 web-sys                  = {version = "0.3.77", optional = true, features = ["Blob", "console", "Document", "Element", "HtmlCanvasElement", "HtmlImageElement", "Response", "Window"]}
 json                     = {version = "0.12.4", optional = true}
-argmin                   = {version = "0.9",    optional = true, features = ["slog-logger", "wasm-bindgen"]}
-argmin-math              = {version = "0.3",    optional = true}
+# argmin                   = {version = "0.10.0", optional = true, features = ["slog-logger", "wasm-bindgen"]}
+argmin                   = {version = "0.10.0", optional = true, features = ["wasm-bindgen"]}
+argmin-math              = {version = "0.4",    optional = true}
+argmin-observer-slog     = {version = "0.1.0",  optional = true}
 libm                     = {version = "0.2",    optional = true}
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ flate2                   = {version = "1.0"   , optional = true}
 getrandom                = {version = "0.2"   , optional = true, features = ["js"]}
 web-sys                  = {version = "0.3.77", optional = true, features = ["Blob", "console", "Document", "Element", "HtmlCanvasElement", "HtmlImageElement", "Response", "Window"]}
 json                     = {version = "0.12.4", optional = true}
-argmin                   = {version = "0.9",    optional = true, features = ["slog-logger"]}
+argmin                   = {version = "0.9",    optional = true, features = ["slog-logger", "wasm-bindgen"]}
 argmin-math              = {version = "0.3",    optional = true}
 libm                     = {version = "0.2",    optional = true}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sparrowhawk"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -12,7 +12,7 @@ wasm = ["js-sys", "wasm-bindgen", "simple-error", "console_error_panic_hook", "w
         "serde", "ahash", "num-traits", "log", "simple_logger", "clap", "regex", "rayon", "num_cpus", "nohash-hasher",
         "stacker", "project-root", "petgraph", "bnum", "json", "argmin", "argmin-math", "libm"]
 basic = ["needletail", "serde", "ahash", "num-traits", "log", "simple_logger", "indicatif", "clap", "regex", "rayon", "num_cpus", "nohash-hasher",
-         "stacker", "plotters", "project-root", "petgraph", "bnum"]
+         "stacker", "plotters", "project-root", "petgraph", "bnum", "argmin", "argmin-math", "libm"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ Current **main features**:
 Currently the only option is to compile from source.
 
 ## Compilation from source
-Development has been done only on x86_64 GNU/Linux-based systems, and most surely will probably stay that way (i.e. no other systems have been tested). To compile our project from source as we did, you will need the [rust toolchain](https://www.rust-lang.org/tools/install) installed in your system. Then, you can download the code with
+Development has been done only on x86_64 GNU/Linux-based systems, and most surely will probably stay that way (i.e. no other systems have been tested). To compile our project from source as we did, you will need the [rust toolchain](https://www.rust-lang.org/tools/install) installed in your system. Then, you can download the code of the e.g. version v0.1.1 using
 
 ```
-git clone https://github.com/bacpop/sparrowhawk.git
+git clone --branch v0.1.1 https://github.com/bacpop/sparrowhawk.git
 ```
 
 sparrowhawk is designed to compile to run natively as a x86_64 binary, but you can also compile it to the WebAssembly target `wasm32-unknown-unknown`. You can see below how to do it manually (as we did for development). Check out [sparrowhawk-web](https://github.com/bacpop/sparrowhawk-web) for an integrated project with Javascript and [wasm-pack](https://github.com/rustwasm/wasm-pack).

--- a/README.md
+++ b/README.md
@@ -98,10 +98,10 @@ Currently, only the `build` option is present (apart from `help`), that allows a
 An example execution could be the following:
 
 ```
-./sparrowhawk -f ./reads.tsv -k 31 --threads 1 -v --min-count 5 -o ./assembly.fasta
+./sparrowhawk -f ./reads.tsv -k 31 --threads 1 -v --min-count 5 --output-dir ./ --output-prefix prefix
 ```
 
-This will assemble your reads, with k=31 and using only one thread. The minimum repeats of one particular k-mer to be considered are 5 (which is also the default). The output contigs will be written as a fasta file called `assembly.fasta`. The input files in this case are provided through a `reads.tsv` tab-separated file, that contains an identifier for your reads and the two file paths separated by a space, i.e. a file that contains this line
+This will assemble your reads, with k=31 and using only one thread. The minimum repeats of one particular k-mer to be considered are 5 (which is also the default). The output contigs will be written in the current directory as a fasta file called `prefix_contigs.fasta`, given that we have indicated, using the `--output-prefix` argument the word "prefix" as prefix. The input files in this case are provided through a `reads.tsv` tab-separated file, that contains an identifier for your reads and the two file paths separated by a space, i.e. a file that contains this line
 
 ```
 IDENTIFIER     /path/to/the/read_1.fastq /path/to/the/read_2.fastq
@@ -110,7 +110,7 @@ IDENTIFIER     /path/to/the/read_1.fastq /path/to/the/read_2.fastq
 Alternatively, you could have run:
 
 ```
-./sparrowhawk /path/to/the/read_1.fastq /path/to/the/read_2.fastq -k 31 --threads 1 -v --min-count 5 -o ./assembly.fasta
+./sparrowhawk /path/to/the/read_1.fastq /path/to/the/read_2.fastq -k 31 --threads 1 -v --min-count 5 --output-dir ./ --output-prefix prefix
 ```
 
-In the same folder as the output FASTA file, the graph before collapsing will be exported in [DOT format](https://en.wikipedia.org/wiki/DOT_%28graph_description_language%29) as `graph.dot`, as well as a histogram of the k-mer frequency spectrum as `histogram.png`. This hardcoded exportation will be adjusted in a future release to add optionality as well as variety of formats as in the web version of sparrowhawk.
+In the same folder as the output FASTA file, the graph before collapsing will be exported in [DOT](https://en.wikipedia.org/wiki/DOT_%28graph_description_language%29), and [GFA](https://gfa-spec.github.io/GFA-spec/) versions 1.1 and 2 as `prefix_graph.dot`, `prefix_graph.gfa`, and `prefix_graph.gfa2` respectively. A histogram of the k-mer frequency spectrum will be saved in the same directory as `prefix_kmerspectrum.png`. These optional files can be avoided with the corresponding arguments.

--- a/src/algorithms/builder.rs
+++ b/src/algorithms/builder.rs
@@ -8,7 +8,7 @@ use crate::HashInfoSimple;
 pub trait Init: Default {
     /// Initialize collection. Arguments are estimated maximum counts of nodes and
     /// edges, as well as type of the input file.
-    fn init(_edges_count: Option<usize>, _nodes_count: Option<usize>, k : usize) -> Self {
+    fn init(_edges_count: Option<usize>, _nodes_count: Option<usize>, _k : usize) -> Self {
         Self::default()
     }
 }

--- a/src/algorithms/collapser.rs
+++ b/src/algorithms/collapser.rs
@@ -7,7 +7,7 @@ use crate::graphs::pt_graph::{CarryType, NodeIndex, NodeStruct, PtGraph};
 use std::cmp::max;
 // use std::process::exit;
 
-use rayon::prelude::*;
+// use rayon::prelude::*;
 use petgraph::EdgeDirection;
 use petgraph::algo::{connected_components, tarjan_scc};
 use petgraph::visit::EdgeRef;
@@ -17,7 +17,7 @@ use petgraph;
 /// Collapse `Graph` into `SerializedContigs`.
 pub trait Collapsable: Shrinkable {
     /// Collapses `Graph` into `SerializedContigs`.
-    fn collapse(self, path : Option<&String>) -> SerializedContigs;
+    fn collapse(self) -> SerializedContigs;
 }
 
 
@@ -30,7 +30,7 @@ pub type SerializedContigs = Vec<Vec<NodeStruct>>;
 
 
 impl Collapsable for PtGraph {
-    fn collapse(mut self, path_ : Option<&String>) -> SerializedContigs {
+    fn collapse(mut self) -> SerializedContigs {
         let mut contigs: SerializedContigs = vec![];
 
         log::info!("Removing self-loops (temporal restriction)");

--- a/src/bloom_filter.rs
+++ b/src/bloom_filter.rs
@@ -145,6 +145,7 @@ impl KmerFilter {
         }
     }
 
+    /// Get method to retrieve the count map
     pub fn get_counts_map(&mut self) -> &mut HashMap::<u64, (u16, u64, u8), BuildHasherDefault<NoHashHasher<u64>>> {
         return &mut self.counts;
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,8 +9,10 @@ pub const DEFAULT_KMER: usize = 31;
 pub const DEFAULT_MINCOUNT: u16 = 5;
 /// Default minimum base quality (PHRED score) for FASTQ files
 pub const DEFAULT_MINQUAL: u8 = 20;
-/// Default minimum base quality (PHRED score) for FASTQ files
-pub const DEFAULT_OUTPUT: &str = "./out.fasta";
+/// Default output directory
+pub const DEFAULT_OUTPUT_DIR:    &str = "./";
+/// Default output prefix
+pub const DEFAULT_OUTPUT_PREFIX: &str = "sphk";
 
 #[doc(hidden)]
 fn valid_kmer(s: &str) -> Result<usize, String> {
@@ -111,9 +113,13 @@ pub enum Commands {
         #[arg(short, group = "input")]
         file_list: Option<String>,
 
+        /// Output directory
+        #[arg(long, default_value_t = DEFAULT_OUTPUT_DIR.to_string())]
+        output_dir: String,
+
         /// Output prefix
-        #[arg(short, default_value_t = DEFAULT_OUTPUT.to_string())]
-        output: String,
+        #[arg(long, default_value_t = DEFAULT_OUTPUT_PREFIX.to_string())]
+        output_prefix: String,
 
         /// K-mer size
         #[arg(short, value_parser = valid_kmer, default_value_t = DEFAULT_KMER)]
@@ -130,6 +136,30 @@ pub enum Commands {
         /// Number of CPU threads
         #[arg(long, value_parser = valid_cpus, default_value_t = 1)]
         threads: usize,
+
+        /// Do the automatic fit to the k-mer spectrum to get the min_count or not
+        #[arg(long, default_value_t = false)]
+        auto_min_count: bool,
+
+        /// Use, instead of the default filtering, a Bloom filter. This will use less memory and be faster, but will add
+        /// false positive matches to the counting, making possible that a k-mer is counted more times that it should be.
+        #[arg(long, default_value_t = false)]
+        do_bloom: bool,
+
+        /// Set a value for the chunks of the reads during preprocessing. A value of zero (the default) ignores chunking.
+        /// Nonzero values enable it, allowing for potential peak memory reduction and speed increase.
+        #[arg(long, default_value_t = 0)]
+        chunk_size: usize,
+
+        /// By default, Sparrowhawk will draw your k-mer spectrum histogram and save it as PNG in the same folder
+        /// where the contigs output will be. Use this argument if you want it to not do this
+        #[arg(long, default_value_t = false)]
+        no_histo: bool,
+
+        /// By default, Sparrowhawk will extract the graph just before collapse and save it in your output folder
+        /// in the DOT, GFAv1.1 and GFAv2 formats. Use this argument if you want it to not do this
+        #[arg(long, default_value_t = false)]
+        no_graphs: bool,
     },
 }
 

--- a/src/fastx_wasm.rs
+++ b/src/fastx_wasm.rs
@@ -1,3 +1,6 @@
+//! Common parsing functions for reading fasta or fastq files, taken from DATACIN
+//! https://github.com/bacpop/DATACIN
+
 use flate2::read::MultiGzDecoder;
 use seq_io::fasta::Reader as FastaReader;
 use seq_io::fastq::Reader as FastqReader;
@@ -8,10 +11,16 @@ const GZ_MAGIC: [u8; 2] = [0x1F, 0x8B];
 // TODO -- would be nice to improve this so the fasta/fastq is transparent
 // like gzipped/not. See https://github.com/onecodex/needletail/blob/master/src/parser/mod.rs
 
+
+/// Enum that allows for alternating between uncompressed and compressed fasta and fastq.
 pub enum ReaderEnum<'a, F: Read + 'a> {
+    /// Uncompressed fasta/fastq
     Plain(Chain<Cursor<[u8; 2]>, &'a mut F>),
+
+    /// g-zipped compressed fasta/fastq
     Gzipped(MultiGzDecoder<Chain<Cursor<[u8; 2]>, &'a mut F>>),
 }
+
 
 impl<'a, F: Read + 'a> Read for ReaderEnum<'a, F> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
@@ -22,6 +31,8 @@ impl<'a, F: Read + 'a> Read for ReaderEnum<'a, F> {
     }
 }
 
+
+/// Returns a reader from a fasta file
 pub fn open_fasta<'a, F>(file_in: &'a mut F) -> FastaReader<ReaderEnum<'a, F>>
 where
     F: Read + 'a,
@@ -41,6 +52,8 @@ where
     }
 }
 
+
+/// Returns a reader from a fastq file
 pub fn open_fastq<'a, F>(file_in: &'a mut F) -> FastqReader<ReaderEnum<'a, F>>
 where
     F: Read + 'a,

--- a/src/graph_works.rs
+++ b/src/graph_works.rs
@@ -238,7 +238,7 @@ impl Assemble for BasicAsm {
         log::info!("Prop. of alone kmers: {:.1} %", (ialone as f64) / (i as f64) * 100.0);
         log::info!("Number of edges {}", (nedges as f64) / (2 as f64));
 
-        // timevec.push(Instant::now());
+        timevec.push(Instant::now());
         log::info!("Neighbours searched for in {} s", timevec.last().unwrap().duration_since(*timevec.get(timevec.len().wrapping_sub(2)).unwrap()).as_secs());
 
         indict.iter().for_each(|(h, hi)| {

--- a/src/graph_works.rs
+++ b/src/graph_works.rs
@@ -13,6 +13,8 @@ use std::{
 };
 
 // use rayon::prelude::*;
+
+#[cfg(not(feature = "wasm"))]
 use super::io_utils::*;
 
 #[cfg(not(feature = "wasm"))]
@@ -236,7 +238,7 @@ impl Assemble for BasicAsm {
         log::info!("Prop. of alone kmers: {:.1} %", (ialone as f64) / (i as f64) * 100.0);
         log::info!("Number of edges {}", (nedges as f64) / (2 as f64));
 
-        timevec.push(Instant::now());
+        // timevec.push(Instant::now());
         log::info!("Neighbours searched for in {} s", timevec.last().unwrap().duration_since(*timevec.get(timevec.len().wrapping_sub(2)).unwrap()).as_secs());
 
         indict.iter().for_each(|(h, hi)| {

--- a/src/graph_works.rs
+++ b/src/graph_works.rs
@@ -4,9 +4,11 @@ use std::{
     time::Instant,
     collections::HashMap,
     hash::BuildHasherDefault,
-    io::Write,
     path::PathBuf,
 };
+
+#[cfg(not(feature = "wasm"))]
+use std::io::Write;
 
 // use rayon::prelude::*;
 use super::io_utils::*;

--- a/src/graph_works.rs
+++ b/src/graph_works.rs
@@ -188,11 +188,13 @@ impl Contigs {
 
 /// Public API for assemblers.
 pub trait Assemble {
+    #[cfg(not(feature = "wasm"))]
     /// Assembles given data using specified `Graph` and writes results into the output file.
     fn assemble<G: Graph>(k : usize, indict : &mut HashMap::<u64, RefCell<HashInfoSimple>, BuildHasherDefault<NoHashHasher<u64>>>,
                           maxminsize : &mut HashMap::<u64, u64, BuildHasherDefault<NoHashHasher<u64>>>, timevec : &mut Vec<Instant>,
                           path : &mut Option<PathBuf>) -> Contigs;
 
+    #[cfg(feature = "wasm")]
     /// Assembles given data using specified `Graph` and prepares all info for being later transferred to Javascript.
     fn assemble_wasm<G: Graph>(k : usize, indict : &mut HashMap::<u64, RefCell<HashInfoSimple>, BuildHasherDefault<NoHashHasher<u64>>>,
                                maxminsize : &mut HashMap::<u64, u64, BuildHasherDefault<NoHashHasher<u64>>>) -> (Contigs, String, String, String);
@@ -205,6 +207,7 @@ pub struct BasicAsm {}
 
 
 impl Assemble for BasicAsm {
+    #[cfg(not(feature = "wasm"))]
     fn assemble<G: Graph>(k        : usize,
                         indict     : &mut HashMap::<u64, RefCell<HashInfoSimple>, BuildHasherDefault<NoHashHasher<u64>>>,
                         maxmindict : &mut HashMap::<u64, u64,                     BuildHasherDefault<NoHashHasher<u64>>>,
@@ -309,10 +312,11 @@ impl Assemble for BasicAsm {
     }
 
 
+    #[cfg(feature = "wasm")]
     fn assemble_wasm<G: Graph>(k        : usize,
                         indict     : &mut HashMap::<u64, RefCell<HashInfoSimple>, BuildHasherDefault<NoHashHasher<u64>>>,
                         maxmindict : &mut HashMap::<u64, u64,                     BuildHasherDefault<NoHashHasher<u64>>>,
-                               ) -> (Contigs, String, String, String) {
+        ) -> (Contigs, String, String, String) {
         log::info!("Starting assembler!");
 
         // FIRST: iterate over all k-mers, check the existance of forwards/backwards neighbours in the dictionary.
@@ -337,7 +341,6 @@ impl Assemble for BasicAsm {
         println!("Prop. of alone kmers: {:.1} %", (ialone as f64) / (i as f64) * 100.0);
         println!("Number of edges {}", (nedges as f64) / (2 as f64));
 
-        // timevec.push(Instant::now());
         // log::info!("Neighbours searched for in {} s", timevec.last().unwrap().duration_since(*timevec.get(timevec.len().wrapping_sub(2)).unwrap()).as_secs());
 
         // indict.iter().for_each(|(h, hi)| {

--- a/src/graph_works.rs
+++ b/src/graph_works.rs
@@ -9,10 +9,8 @@ use std::{
 use std::{
     time::Instant,
     path::PathBuf,
+    io::Write,
 };
-
-#[cfg(not(feature = "wasm"))]
-use std::io::Write;
 
 // use rayon::prelude::*;
 use super::io_utils::*;
@@ -238,7 +236,7 @@ impl Assemble for BasicAsm {
         log::info!("Prop. of alone kmers: {:.1} %", (ialone as f64) / (i as f64) * 100.0);
         log::info!("Number of edges {}", (nedges as f64) / (2 as f64));
 
-        timevec.push(Instant::now());
+        // timevec.push(Instant::now());
         log::info!("Neighbours searched for in {} s", timevec.last().unwrap().duration_since(*timevec.get(timevec.len().wrapping_sub(2)).unwrap()).as_secs());
 
         indict.iter().for_each(|(h, hi)| {

--- a/src/graph_works.rs
+++ b/src/graph_works.rs
@@ -1,10 +1,14 @@
-use std::cell::*;
-use std::time::Instant;
 use nohash_hasher::NoHashHasher;
-use std::{collections::HashMap, hash::BuildHasherDefault};
+use std::{
+    cell::*,
+    time::Instant,
+    collections::HashMap,
+    hash::BuildHasherDefault,
+    io::Write,
+    path::PathBuf,
+};
 
-use rayon::prelude::*;
-use std::io::Write;
+// use rayon::prelude::*;
 use super::io_utils::*;
 
 #[cfg(not(feature = "wasm"))]
@@ -150,7 +154,7 @@ impl Contigs {
 
     /// Temporal and historical function to simplify contigs. To be removed in the future
     pub fn shrink(&mut self) {
-        log::warn!("Contigs are going to be shrunk!");
+        // log::warn!("Contigs are going to be shrunk!");
 
         for ic in 0..self.serialized_contigs.len() {
             let mut tmpv = self.serialized_contigs[ic][0].abs_ind.clone();
@@ -185,26 +189,137 @@ pub trait Assemble {
     /// Assembles given data using specified `Graph` and writes results into the output file.
     fn assemble<G: Graph>(k : usize, indict : &mut HashMap::<u64, RefCell<HashInfoSimple>, BuildHasherDefault<NoHashHasher<u64>>>,
                           maxminsize : &mut HashMap::<u64, u64, BuildHasherDefault<NoHashHasher<u64>>>, timevec : &mut Vec<Instant>,
-                          path : Option<&String>) -> (Contigs, String, String, String);
+                          path : &mut Option<PathBuf>) -> Contigs;
+
+    /// Assembles given data using specified `Graph` and prepares all info for being later transferred to Javascript.
+    fn assemble_wasm<G: Graph>(k : usize, indict : &mut HashMap::<u64, RefCell<HashInfoSimple>, BuildHasherDefault<NoHashHasher<u64>>>,
+                               maxminsize : &mut HashMap::<u64, u64, BuildHasherDefault<NoHashHasher<u64>>>) -> (Contigs, String, String, String);
 }
 
 
 ///////////////////////////////////////////////////////////
-/// Basic assembler.
+/// Basic standalone assembler.
 pub struct BasicAsm {}
 
 
 impl Assemble for BasicAsm {
-    fn assemble<G: Graph>(k    : usize,
+    fn assemble<G: Graph>(k        : usize,
                         indict     : &mut HashMap::<u64, RefCell<HashInfoSimple>, BuildHasherDefault<NoHashHasher<u64>>>,
                         maxmindict : &mut HashMap::<u64, u64,                     BuildHasherDefault<NoHashHasher<u64>>>,
-                        timevec    : &mut Vec<Instant>, path : Option<&String>) -> (Contigs, String, String, String) {
+                        timevec    : &mut Vec<Instant>,
+                        path       : &mut Option<PathBuf>) -> Contigs {
         log::info!("Starting assembler!");
 
         // FIRST: iterate over all k-mers, check the existance of forwards/backwards neighbours in the dictionary.
         let mut i = 0;
         let mut ialone = 0;
         let mut nedges = 0;
+        indict.iter().for_each(|(h, hi)| {
+            let mut himutref = hi.borrow_mut();
+
+            himutref.pre  = check_bkg(*h, himutref.hnc, k, himutref.b, indict, maxmindict);
+            himutref.post = check_fwd(*h, himutref.hnc, k, himutref.b, indict, maxmindict);
+            let tmpnedges = himutref.pre.len() + himutref.post.len();
+            nedges += tmpnedges;
+            i += 1;
+            if tmpnedges == 0 { ialone += 1};
+        });
+
+//         drop(maxmindict);
+        log::info!("Prop. of alone kmers: {:.1} %", (ialone as f64) / (i as f64) * 100.0);
+        log::info!("Number of edges {}", (nedges as f64) / (2 as f64));
+
+        timevec.push(Instant::now());
+        log::info!("Neighbours searched for in {} s", timevec.last().unwrap().duration_since(*timevec.get(timevec.len().wrapping_sub(2)).unwrap()).as_secs());
+
+        indict.iter().for_each(|(h, hi)| {
+            let himutref = hi.borrow();
+
+            // Check first previous neighbours:
+            for ipre in himutref.pre.iter() {
+                if !indict.get(&ipre.0).unwrap().borrow().pre.contains(&(*h, ipre.1.rev())) || !indict.get(&ipre.0).unwrap().borrow().post.contains(&(*h, ipre.1)) {
+                    println!("HEY");
+                }
+            }
+            for ipost in himutref.post.iter() {
+                if !indict.get(&ipost.0).unwrap().borrow().post.contains(&(*h, ipost.1.rev())) || !indict.get(&ipost.0).unwrap().borrow().pre.contains(&(*h, ipost.1)) {
+                    println!("HEY");
+                }
+            }
+        });
+
+        let mut ptgraph = G::create_from_map::<G>(k, indict);
+
+
+        // log::info!("Saving graph (pre-shrink w/o one-node contigs) as DOT file...");
+        // if path_.is_some() {
+        //     let mut wbuf = set_ostream(&Some(path_.unwrap().clone().replace(".dot", "_preshrink.dot")));
+        //     ptgraph.write_to_dot(&mut wbuf);
+        // }
+        // log::info!("Done.");
+
+        log::info!("Starting shrinkage and pruning of the graph");
+
+        log::info!("Removing self-loops (temporal restriction)");
+        ptgraph.remove_self_loops();
+
+        // let minnts = 100; // independent of this value, the minimum number of nts will be always k
+        // let limit = max(0, minnts - k + 1);
+
+        let mut didanyofusdoanything = true;
+        while didanyofusdoanything {
+            let bools = ptgraph.shrink();
+            // let bools = false;
+            let boolr = ptgraph.remove_dead_paths();
+            // let boolr = false;
+    //             println!("{} {}", bools, boolr);
+            didanyofusdoanything = bools || boolr;
+            // break;
+        }
+        log::info!("Shrinkage and pruning finished");
+
+        if path.is_some() {
+            log::info!("Saving graph (post-shrink, pre-collapse, w/o one-node contigs) as DOT, GFAv1.1, and GFAv2 files...");
+            let pathmutref = path.as_mut().unwrap();
+            pathmutref.set_extension("dot");
+            let mut wbufdot = set_ostream(&Some(pathmutref.clone().into_os_string().into_string().unwrap()));
+            ptgraph.write_to_dot(&mut wbufdot);
+
+            pathmutref.set_extension("gfa");
+            let mut wbufgfa = set_ostream(&Some(pathmutref.clone().into_os_string().into_string().unwrap()));
+            ptgraph.write_to_gfa(&mut wbufgfa);
+
+            pathmutref.set_extension("gfa2");
+            let mut wbufgfa2 = set_ostream(&Some(pathmutref.clone().into_os_string().into_string().unwrap()));
+            ptgraph.write_to_gfa2(&mut wbufgfa2);
+            log::info!("Done.");
+        }
+
+
+        let serialized_contigs = ptgraph.collapse();
+        log::info!("I created {} contigs", serialized_contigs.len());
+        let mut contigs = Contigs::new(serialized_contigs);
+
+        // TEMPORAL RESTRICTION, WIP
+        contigs.shrink();
+
+        contigs
+    }
+
+
+    fn assemble_wasm<G: Graph>(k        : usize,
+                        indict     : &mut HashMap::<u64, RefCell<HashInfoSimple>, BuildHasherDefault<NoHashHasher<u64>>>,
+                        maxmindict : &mut HashMap::<u64, u64,                     BuildHasherDefault<NoHashHasher<u64>>>,
+                               ) -> (Contigs, String, String, String) {
+        log::info!("Starting assembler!");
+
+        // FIRST: iterate over all k-mers, check the existance of forwards/backwards neighbours in the dictionary.
+        let mut i = 0;
+        let mut ialone = 0;
+        let mut nedges = 0;
+
+        // TODO: explore parallelisation?
+
         indict.iter().for_each(|(h, hi)| {
             let mut himutref = hi.borrow_mut();
 
@@ -239,62 +354,48 @@ impl Assemble for BasicAsm {
         //     }
         // });
 
-        let ptgraph = G::create_from_map::<G>(k, indict);
+        let mut ptgraph = G::create_from_map::<G>(k, indict);
 
-        assemble_with_bi_graph(ptgraph, timevec, path)
+
+        // log::info!("Saving graph (pre-shrink w/o one-node contigs) as DOT file...");
+        // if path_.is_some() {
+        //     let mut wbuf = set_ostream(&Some(path_.unwrap().clone().replace(".dot", "_preshrink.dot")));
+        //     ptgraph.write_to_dot(&mut wbuf);
+        // }
+        // log::info!("Done.");
+
+        log::info!("Starting shrinkage and pruning of the graph");
+
+        log::info!("Removing self-loops (temporal restriction)");
+        ptgraph.remove_self_loops();
+
+        // let minnts = 100; // independent of this value, the minimum number of nts will be always k
+        // let limit = max(0, minnts - k + 1);
+
+        let mut didanyofusdoanything = true;
+        while didanyofusdoanything {
+            let bools = ptgraph.shrink();
+            // let bools = false;
+            let boolr = ptgraph.remove_dead_paths();
+            // let boolr = false;
+    //             println!("{} {}", bools, boolr);
+            didanyofusdoanything = bools || boolr;
+            // break;
+        }
+        log::info!("Shrinkage and pruning finished");
+
+        let outdot  = ptgraph.get_dot_string();
+        let outgfa  = ptgraph.get_gfa_string();
+        let outgfa2 = ptgraph.get_gfa2_string();
+
+        let serialized_contigs = ptgraph.collapse();
+        log::info!("I created {} contigs", serialized_contigs.len());
+        let mut contigs = Contigs::new(serialized_contigs);
+
+        // TEMPORAL RESTRICTION, WIP
+        contigs.shrink();
+
+        (contigs, outdot, outgfa, outgfa2)
     }
 }
 
-
-/// Assemble a bidirected DNA de Bruijn graph
-fn assemble_with_bi_graph<G: Graph>(mut ptgraph: G, timevec : &mut Vec<Instant>, path_ : Option<&String>)
--> (Contigs, String, String, String) {
-
-    // log::info!("Saving graph (pre-shrink w/o one-node contigs) as DOT file...");
-    // if path_.is_some() {
-    //     let mut wbuf = set_ostream(&Some(path_.unwrap().clone().replace(".dot", "_preshrink.dot")));
-    //     ptgraph.write_to_dot(&mut wbuf);
-    // }
-    // log::info!("Done.");
-
-    log::info!("Starting shrinkage and pruning of the graph");
-
-    log::info!("Removing self-loops (temporal restriction)");
-    ptgraph.remove_self_loops();
-
-    // let minnts = 100; // independent of this value, the minimum number of nts will be always k
-    // let limit = max(0, minnts - k + 1);
-
-    let mut didanyofusdoanything = true;
-    while didanyofusdoanything {
-        let bools = ptgraph.shrink();
-        // let bools = false;
-        let boolr = ptgraph.remove_dead_paths();
-        // let boolr = false;
-//             println!("{} {}", bools, boolr);
-        didanyofusdoanything = bools || boolr;
-        // break;
-    }
-    log::info!("Shrinkage and pruning finished");
-
-
-    log::info!("Saving graph (post-shrink, pre-collapse, w/o one-node contigs) as DOT file...");
-    if path_.is_some() {
-        let mut wbuf = set_ostream(&Some(path_.unwrap().clone()));
-        ptgraph.write_to_dot(&mut wbuf);
-    }
-    log::info!("Done.");
-
-    let outdot  = ptgraph.get_dot_string();
-    let outgfa  = ptgraph.get_gfa_string();
-    let outgfa2 = ptgraph.get_gfa2_string();
-
-    let serialized_contigs = ptgraph.collapse(path_);
-    log::info!("I created {} contigs", serialized_contigs.len());
-    let mut contigs = Contigs::new(serialized_contigs);
-
-    // TEMPORAL RESTRICTION, WIP
-    contigs.shrink();
-
-    (contigs, outdot, outgfa, outgfa2)
-}

--- a/src/graph_works.rs
+++ b/src/graph_works.rs
@@ -236,7 +236,7 @@ impl Assemble for BasicAsm {
         log::info!("Prop. of alone kmers: {:.1} %", (ialone as f64) / (i as f64) * 100.0);
         log::info!("Number of edges {}", (nedges as f64) / (2 as f64));
 
-        // timevec.push(Instant::now());
+        timevec.push(Instant::now());
         log::info!("Neighbours searched for in {} s", timevec.last().unwrap().duration_since(*timevec.get(timevec.len().wrapping_sub(2)).unwrap()).as_secs());
 
         indict.iter().for_each(|(h, hi)| {

--- a/src/graph_works.rs
+++ b/src/graph_works.rs
@@ -1,9 +1,13 @@
 use nohash_hasher::NoHashHasher;
 use std::{
     cell::*,
-    time::Instant,
     collections::HashMap,
     hash::BuildHasherDefault,
+};
+
+#[cfg(not(feature = "wasm"))]
+use std::{
+    time::Instant,
     path::PathBuf,
 };
 

--- a/src/graphs/pt_graph.rs
+++ b/src/graphs/pt_graph.rs
@@ -442,8 +442,8 @@ impl Graph for PtGraph {
 
     #[inline]
     fn in_neighbours_min(&self, node: Self::NodeIdentifier) -> Vec<(NodeIndex, EdgeType)> {
-        let tmpoutneigh = self.graph.edges_directed(node, petgraph::EdgeDirection::Incoming).collect::<Vec<_>>();
-        let mut outneigh =Vec::new();
+        let     tmpoutneigh = self.graph.edges_directed(node, petgraph::EdgeDirection::Incoming).collect::<Vec<_>>();
+        let mut outneigh    = Vec::new();
         for ie in tmpoutneigh.iter() {
             match ie.weight().t {
                 EdgeType::MinToMin | EdgeType::MaxToMin => outneigh.push( (ie.source(), ie.weight().t) ),
@@ -455,8 +455,8 @@ impl Graph for PtGraph {
 
     #[inline]
     fn in_neighbours_max(&self, node: Self::NodeIdentifier) -> Vec<(NodeIndex, EdgeType)> {
-        let tmpoutneigh = self.graph.edges_directed(node, petgraph::EdgeDirection::Incoming).collect::<Vec<_>>();
-        let mut outneigh =Vec::new();
+        let     tmpoutneigh = self.graph.edges_directed(node, petgraph::EdgeDirection::Incoming).collect::<Vec<_>>();
+        let mut outneigh    = Vec::new();
         for ie in tmpoutneigh.iter() {
             match ie.weight().t {
                 EdgeType::MinToMax | EdgeType::MaxToMax => outneigh.push( (ie.source(), ie.weight().t) ),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,14 +306,13 @@ pub fn main() {
 }
 
 
+// ===================================== WebAssembly stuff follows
 #[cfg(feature = "wasm")]
 /// Binary dummy function. In the future, we need to completely remove it whenever compilating with the feature "wasm"
 pub fn main() {
     panic!("You've compiled Sparrowhawk for WebAssembly support, you cannot use it as a normal binary anymore!");
 }
 
-
-// ===================================== WebAssembly stuff follows
 
 #[cfg(feature = "wasm")]
 #[wasm_bindgen]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,8 +158,8 @@ impl fmt::Display for QualOpts {
 pub fn main() {
     let args = cli_args();
     if args.verbose {
-        simple_logger::init_with_level(log::Level::Trace).unwrap();
-        // simple_logger::init_with_level(log::Level::Info).unwrap();
+        // simple_logger::init_with_level(log::Level::Trace).unwrap();
+        simple_logger::init_with_level(log::Level::Info).unwrap();
     } else {
         simple_logger::init_with_level(log::Level::Warn).unwrap();
     }

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -1850,7 +1850,7 @@ where
             qual,
             &mut tmpvec);
 
-        // timevec.push(Instant::now());
+        timevec.push(Instant::now());
         log::info!("Kmers extracted in {} s", timevec.last().unwrap().duration_since(*timevec.get(timevec.len().wrapping_sub(2)).unwrap()).as_secs());
 
 
@@ -1859,11 +1859,11 @@ where
         log::info!("Sorting vector");
         tmpvec.par_sort_unstable_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
 
-        // timevec.push(Instant::now());
+        timevec.push(Instant::now());
         log::info!("Kmers sorted in {} s", timevec.last().unwrap().duration_since(*timevec.get(timevec.len().wrapping_sub(2)).unwrap()).as_secs());
 
         // Then, do a counting of everything and save the results in a dictionary and return it
-        // timevec.push(Instant::now());
+        timevec.push(Instant::now());
         log::info!("Counting k-mers");
         let themap;
 
@@ -1874,7 +1874,7 @@ where
         }
         drop(tmpvec);
 
-        // timevec.push(Instant::now());
+        timevec.push(Instant::now());
         log::info!("Kmers counted in {} s", timevec.last().unwrap().duration_since(*timevec.get(timevec.len().wrapping_sub(2)).unwrap()).as_secs());
 
         return (themap, theseq, thedict, maxmindict)

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -4,12 +4,9 @@ use core::panic;
 use std::time::Instant;
 
 use nohash_hasher::NoHashHasher;
-use std::{collections::HashMap, hash::BuildHasherDefault, cell::*};
+use std::{collections::HashMap, hash::BuildHasherDefault, cell::*, path::PathBuf, cmp::Ordering};
 
 use rayon::prelude::*;
-
-#[cfg(not(feature = "wasm"))]
-use indicatif::ProgressIterator;
 
 #[cfg(not(feature = "wasm"))]
 use needletail::parse_fastx_file;
@@ -19,7 +16,6 @@ use needletail::parse_fastx_file;
 #[cfg(not(feature = "wasm"))]
 use plotters::prelude::*;
 
-use project_root;
 
 use super::QualOpts;
 use super::HashInfoSimple;
@@ -27,7 +23,9 @@ use super::bit_encoding::{encode_base, rc_base};
 use crate::io_utils::any_fastq;
 use crate::bit_encoding::UInt;
 use crate::kmer::Kmer;
-use crate::loG;
+use crate::logw;
+use crate::spectrum_fitter::SpectrumFitter;
+use crate::bloom_filter::KmerFilter;
 
 
 /// Tuple for name and fasta or paired fastq input
@@ -41,11 +39,8 @@ use wasm_bindgen_file_reader::WebSysFile;
 use crate::fastx_wasm::open_fastq;
 #[cfg(feature = "wasm")]
 use seq_io::fastq::Record;
-#[cfg(feature = "wasm")]
-use crate::bloom_filter::KmerFilter;
-#[cfg(feature = "wasm")]
-use std::cmp::Ordering;
 
+// For the fitting, we'll use actually MAXSIZEHISTO - 1
 const MAXSIZEHISTO : usize = 500;
 
 // =====================================================================================================
@@ -152,7 +147,8 @@ where
 //             numkmers += 1;
             let (hc, hnc, b, km) = kmer_it.get_curr_kmerhash_and_bases_and_kmer();
             outvec.push( (hc, hnc, b) );
-            let testkm = outdict.entry(hc).or_insert(km);
+            outdict.entry(hc).or_insert(km);
+            // let testkm = outdict.entry(hc).or_insert(km);
             // if *testkm != km {
             //     log::debug!("\n\t- COLLISIONS 1 !!! Hash: {:?}", hc);
             //     log::debug!("{:#0258b}\n{:#0258b}", *testkm, km);
@@ -164,7 +160,8 @@ where
             while let Some(tmptuple) = kmer_it.get_next_kmer_and_give_us_things() {
                 let (hc, hnc, b, km) = tmptuple;
                 outvec.push( (hc, hnc, b) );
-                let testkm = outdict.entry(hc).or_insert(km);
+                outdict.entry(hc).or_insert(km);
+                // let testkm = outdict.entry(hc).or_insert(km);
                 // if *testkm != km {
                 //     log::debug!("\n\t- COLLISIONS 2 !!! Hash: {:?}", hc);
                 //     log::debug!("{:#0258b}\n{:#0258b}", *testkm, km);
@@ -215,7 +212,8 @@ where
 //             numkmers += 1;
             let (hc, hnc, b, km) = kmer_it.get_curr_kmerhash_and_bases_and_kmer();
             outvec.push( (hc, hnc, b) );
-            let testkm = outdict.entry(hc).or_insert(km);
+            outdict.entry(hc).or_insert(km);
+            // let testkm = outdict.entry(hc).or_insert(km);
             // if *testkm != km {
             //     log::debug!("\n\t- COLLISIONS 3 !!! Hash: {:?}", hc);
             //     log::debug!("{:#0258b}\n{:#0258b}", *testkm, km);
@@ -227,7 +225,8 @@ where
             while let Some(tmptuple) = kmer_it.get_next_kmer_and_give_us_things() {
                 let (hc, hnc, b, km) = tmptuple;
                 outvec.push( (hc, hnc, b) );
-                let testkm = outdict.entry(hc).or_insert(km);
+                outdict.entry(hc).or_insert(km);
+                // let testkm = outdict.entry(hc).or_insert(km);
                 // if *testkm != km {
                 //     log::debug!("\n\t- COLLISIONS 4 !!! Hash: {:?}", hc);
                 //     log::debug!("{:#0258b}\n{:#0258b}", *testkm, km);
@@ -274,10 +273,10 @@ where
 {
     let mut outdict    = HashMap::with_hasher(BuildHasherDefault::default());
     let mut minmaxdict = HashMap::with_hasher(BuildHasherDefault::default());
-    loG("Getting kmers from first file. Creating reader...", Some("info"));
+    logw("Getting kmers from first file. Creating reader...", Some("info"));
     let mut reader = open_fastq(file1);
 
-    loG("Entering while loop...", Some("info"));
+    logw("Entering while loop...", Some("info"));
 
 //     let maxkmers = 200;
 //     let mut numkmers = 0;
@@ -297,10 +296,11 @@ where
 //             numkmers += 1;
             let (hc, hnc, b, km) = kmer_it.get_curr_kmerhash_and_bases_and_kmer();
             outvec.push( (hc, hnc, b) );
-            let testkm = outdict.entry(hc).or_insert(km);
+            outdict.entry(hc).or_insert(km);
+            // let testkm = outdict.entry(hc).or_insert(km);
             // if *testkm != km {
-            //     loG(format!("\n\t- COLLISIONS 1 !!! Hash: {:?}", hc).as_str(), Some("warn"));
-            //     loG(format!("{:#0258b}\n{:#0258b}", *testkm, km).as_str(), Some("warn"));
+            //     logw(format!("\n\t- COLLISIONS 1 !!! Hash: {:?}", hc).as_str(), Some("warn"));
+            //     logw(format!("{:#0258b}\n{:#0258b}", *testkm, km).as_str(), Some("warn"));
             // }
             // } else {
             //     log::debug!("\n\t\t- NOT COLLISIONS!!!");
@@ -309,10 +309,11 @@ where
             while let Some(tmptuple) = kmer_it.get_next_kmer_and_give_us_things() {
                 let (hc, hnc, b, km) = tmptuple;
                 outvec.push( (hc, hnc, b) );
-                let testkm = outdict.entry(hc).or_insert(km);
+                outdict.entry(hc).or_insert(km);
+                // let testkm = outdict.entry(hc).or_insert(km);
                 // if *testkm != km {
-                //     loG(format!("\n\t- COLLISIONS 2 !!! Hash: {:?}", hc).as_str(), Some("warn"));
-                //     loG(format!("{:#0258b}\n{:#0258b}", *testkm, km).as_str(), Some("warn"));
+                //     logw(format!("\n\t- COLLISIONS 2 !!! Hash: {:?}", hc).as_str(), Some("warn"));
+                //     logw(format!("{:#0258b}\n{:#0258b}", *testkm, km).as_str(), Some("warn"));
                 // }
                 // } else {
                 //     log::debug!("\n\t\t- NOT COLLISIONS!!!");
@@ -324,7 +325,7 @@ where
             }
         }
     }
-    loG("Finished getting kmers from first file. Starting with the second...", Some("info"));
+    logw("Finished getting kmers from first file. Starting with the second...", Some("info"));
 //     numkmers = 0;
 
     let mut reader = open_fastq(file2);
@@ -347,10 +348,11 @@ where
 //             numkmers += 1;
             let (hc, hnc, b, km) = kmer_it.get_curr_kmerhash_and_bases_and_kmer();
             outvec.push( (hc, hnc, b) );
-            let testkm = outdict.entry(hc).or_insert(km);
+            outdict.entry(hc).or_insert(km);
+            // let testkm = outdict.entry(hc).or_insert(km);
             // if *testkm != km {
-            //     loG(format!("\n\t- COLLISIONS 3 !!! Hash: {:?}", hc).as_str(), Some("warn"));
-            //     loG(format!("{:#0258b}\n{:#0258b}", *testkm, km).as_str(), Some("warn"));
+            //     logw(format!("\n\t- COLLISIONS 3 !!! Hash: {:?}", hc).as_str(), Some("warn"));
+            //     logw(format!("{:#0258b}\n{:#0258b}", *testkm, km).as_str(), Some("warn"));
             // }
             // } else {
             //     log::debug!("\n\t\t- NOT COLLISIONS!!!");
@@ -359,10 +361,11 @@ where
             while let Some(tmptuple) = kmer_it.get_next_kmer_and_give_us_things() {
                 let (hc, hnc, b, km) = tmptuple;
                 outvec.push( (hc, hnc, b) );
-                let testkm = outdict.entry(hc).or_insert(km);
+                outdict.entry(hc).or_insert(km);
+                // let testkm = outdict.entry(hc).or_insert(km);
                 // if *testkm != km {
-                //     loG(format!("\n\t- COLLISIONS 4 !!! Hash: {:?}", hc).as_str(), Some("warn"));
-                //     loG(format!("{:#0258b}\n{:#0258b}", *testkm, km).as_str(), Some("warn"));
+                //     logw(format!("\n\t- COLLISIONS 4 !!! Hash: {:?}", hc).as_str(), Some("warn"));
+                //     logw(format!("{:#0258b}\n{:#0258b}", *testkm, km).as_str(), Some("warn"));
                 // }
                 // } else {
                 //     log::debug!("\n\t\t- NOT COLLISIONS!!!");
@@ -377,7 +380,7 @@ where
         // itrecord += rl as u32;
     }
 
-    loG("Finished getting kmers from the second file", Some("info"));
+    logw("Finished getting kmers from the second file", Some("info"));
 
 
     (outdict, minmaxdict)
@@ -396,7 +399,7 @@ fn chunked_processing_wasm<IntT>(
 where
     IntT: for<'a> UInt<'a>,
 {
-    loG("Getting kmers from first file. Creating reader...", Some("info"));
+    logw("Getting kmers from first file. Creating reader...", Some("info"));
 
     let mut outdict    = HashMap::with_hasher(BuildHasherDefault::default());
     let mut minmaxdict = HashMap::with_hasher(BuildHasherDefault::default());
@@ -406,7 +409,7 @@ where
     let mut reader = open_fastq(file1);
     let mut histovec : Vec<u32> = vec![0; MAXSIZEHISTO];
 
-    loG("Entering while loop...", Some("info"));
+    logw("Entering while loop...", Some("info"));
 
     let mut i_record = 0;
 
@@ -438,9 +441,9 @@ where
         if i_record >= csize {
             // Processssssss! And reset.
             if !outvec.is_empty() {
-                loG("Processing chunk. Sorting k-mers...", Some("info"));
+                logw("Processing chunk. Sorting k-mers...", Some("info"));
                 outvec.par_sort_unstable_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
-                loG("k-mers sorted. Counting k-mers...", Some("info"));
+                logw("k-mers sorted. Counting k-mers...", Some("info"));
                 // Then, do a counting of everything and save the results in a dictionary and return it
 
                 update_countmap(&outvec, &mut countmap);
@@ -452,7 +455,7 @@ where
         }
 
     }
-    loG("Finished getting kmers from first file. Starting with the second...", Some("info"));
+    logw("Finished getting kmers from first file. Starting with the second...", Some("info"));
 
     let mut reader = open_fastq(file2);
 
@@ -486,9 +489,9 @@ where
         if i_record >= csize {
             // Processssssss! And reset.
             if !outvec.is_empty() {
-                loG("Processing chunk. Sorting k-mers...", Some("info"));
+                logw("Processing chunk. Sorting k-mers...", Some("info"));
                 outvec.par_sort_unstable_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
-                loG("k-mers sorted. Counting k-mers...", Some("info"));
+                logw("k-mers sorted. Counting k-mers...", Some("info"));
                 // Then, do a counting of everything and save the results in a dictionary and return it
 
                 update_countmap(&outvec, &mut countmap);
@@ -503,9 +506,9 @@ where
     if i_record > 0 {
         // Processssssss! And reset.
         if !outvec.is_empty() {
-            loG("Processing last chunk. Sorting k-mers...", Some("info"));
+            logw("Processing last chunk. Sorting k-mers...", Some("info"));
             outvec.par_sort_unstable_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
-            loG("k-mers sorted. Counting k-mers...", Some("info"));
+            logw("k-mers sorted. Counting k-mers...", Some("info"));
             // Then, do a counting of everything and save the results in a dictionary and return it
 
             update_countmap(&outvec, &mut countmap);
@@ -513,8 +516,8 @@ where
         // Reset
         outvec.clear();
     }
-    loG("Finished getting kmers from the second file", Some("info"));
-    loG("Filtering...", Some("info"));
+    logw("Finished getting kmers from the second file", Some("info"));
+    logw("Filtering...", Some("info"));
 
     // Now, get themap, histovec, and filter outdict and minmaxdict
     countmap.shrink_to_fit();
@@ -562,7 +565,7 @@ fn bloom_filter_preprocessing_wasm<IntT>(
 where
     IntT: for<'a> UInt<'a>,
 {
-    loG("Getting kmers from first file with Bloom filter. Creating reader and initialising filter...", Some("info"));
+    logw("Getting kmers from first file with Bloom filter. Creating reader and initialising filter...", Some("info"));
 
     let mut outdict    = HashMap::with_hasher(BuildHasherDefault::default());
     let mut minmaxdict = HashMap::with_hasher(BuildHasherDefault::default());
@@ -574,7 +577,7 @@ where
     let mut kmer_filter = KmerFilter::new(qual.min_count);
     kmer_filter.init();
 
-    loG("Entering while loop for the first file...", Some("info"));
+    logw("Entering while loop for the first file...", Some("info"));
 
     while let Some(record) = reader.next() {
         let seqrec = record.expect("Invalid FASTQ record");
@@ -604,7 +607,7 @@ where
 
 
     }
-    loG("Finished getting kmers from first file. Starting with the second...", Some("info"));
+    logw("Finished getting kmers from first file. Starting with the second...", Some("info"));
 
     let mut reader = open_fastq(file2);
 
@@ -637,8 +640,8 @@ where
         }
     }
 
-    loG("Finished getting kmers from the second file", Some("info"));
-    loG("Second part of filtering...", Some("info"));
+    logw("Finished getting kmers from the second file", Some("info"));
+    logw("Second part of filtering...", Some("info"));
 
     // Now, get themap, histovec, and filter outdict and minmaxdict
     let mut countmap = kmer_filter.get_counts_map();
@@ -676,47 +679,418 @@ where
 
 
 #[cfg(not(feature = "wasm"))]
-fn get_map_with_counts_with_hashes_only(
+fn bloom_filter_preprocessing_standalone<IntT>(
+    file1:  &str,
+    file2:  &str,
+    k:      usize,
+    qual:   &QualOpts,
+    do_fit: bool,
+    out_path: &mut Option<PathBuf>,
+) -> (HashMap::<u64, IntT, BuildHasherDefault<NoHashHasher<u64>>>, HashMap::<u64, u64, BuildHasherDefault<NoHashHasher<u64>>>, HashMap::<u64, RefCell<HashInfoSimple>, BuildHasherDefault<NoHashHasher<u64>>>)
+where
+    IntT: for<'a> UInt<'a>,
+{
+    log::info!("Getting kmers from first file with Bloom filter. Creating reader and initialising filter...");
+
+    let mut outdict    = HashMap::with_hasher(BuildHasherDefault::default());
+    let mut minmaxdict = HashMap::with_hasher(BuildHasherDefault::default());
+    let mut themap     = HashMap::with_hasher(BuildHasherDefault::default());
+
+    let mut reader =
+        parse_fastx_file(file1).unwrap_or_else(|_| panic!("Invalid path/file: {file1}"));
+    let mut histovec : Vec<u32> = vec![0; MAXSIZEHISTO];
+
+    let mut kmer_filter = KmerFilter::new(qual.min_count);
+    kmer_filter.init();
+
+    logw(format!("Entering while loop for the first file...").as_str(), Some("info"));
+
+    while let Some(record) = reader.next() {
+        let seqrec = record.expect("Invalid FASTQ record");
+        let rl = seqrec.seq().len();
+        let kmer_opt = Kmer::<IntT>::new(
+            seqrec.seq(),
+            rl,
+            seqrec.qual(),
+            k,
+            qual.min_qual,
+            true,
+        );
+        if let Some(mut kmer_it) = kmer_opt {
+            let (hc, hnc, b, km) = kmer_it.get_curr_kmerhash_and_bases_and_kmer(); // TODO: potential really small improvement, get only hash for the bloom filter, then get the rest.
+            if Ordering::is_eq(kmer_filter.filter(hc, hnc, b)) {
+                outdict.entry(hc).or_insert(km);
+                minmaxdict.entry(hnc).or_insert(hc);
+            }
+            while let Some(tmptuple) = kmer_it.get_next_kmer_and_give_us_things() {
+                let (hc, hnc, b, km) = tmptuple;
+                if Ordering::is_eq(kmer_filter.filter(hc, hnc, b)) {
+                    outdict.entry(hc).or_insert(km);
+                    minmaxdict.entry(hnc).or_insert(hc);
+                }
+            }
+        }
+
+
+    }
+    log::info!("Finished getting kmers from first file. Starting with the second...");
+
+    reader =
+        parse_fastx_file(file2).unwrap_or_else(|_| panic!("Invalid path/file: {file2}"));
+
+    // Filling the seq of the second file!
+    while let Some(record) = reader.next() {
+        let seqrec = record.expect("Invalid FASTQ record");
+        // put_these_nts_into_an_efficient_vector_rc(&seqrec.seq(), &mut theseq, (itrecord % 32) as u8);
+        let rl = seqrec.seq().len();
+        let kmer_opt = Kmer::<IntT>::new(
+            seqrec.seq(),
+            rl,
+            seqrec.qual(),
+            k,
+            qual.min_qual,
+            true,
+        );
+        if let Some(mut kmer_it) = kmer_opt {
+            let (hc, hnc, b, km) = kmer_it.get_curr_kmerhash_and_bases_and_kmer();
+            if Ordering::is_eq(kmer_filter.filter(hc, hnc, b)) {
+                outdict.entry(hc).or_insert(km);
+                minmaxdict.entry(hnc).or_insert(hc);
+            }
+            while let Some(tmptuple) = kmer_it.get_next_kmer_and_give_us_things() {
+                let (hc, hnc, b, km) = tmptuple;
+                if Ordering::is_eq(kmer_filter.filter(hc, hnc, b)) {
+                    outdict.entry(hc).or_insert(km);
+                    minmaxdict.entry(hnc).or_insert(hc);
+                }
+            }
+        }
+    }
+
+    log::info!("Finished getting kmers from the second file");
+    log::info!("Second part of filtering...");
+
+    // Now, get themap, histovec, and filter outdict and minmaxdict
+    let countmap = kmer_filter.get_counts_map();
+    countmap.shrink_to_fit();
+    let minc;
+
+    // This can be optimised. also better written: I had to repeat the code for the retains, to try to improve slightly the running time in
+    // case no autofitting is requested. In any case, it could be improved in the future.
+    if do_fit {
+        for tup in countmap.iter() {
+            if *tup.0 as usize > MAXSIZEHISTO {
+                histovec[MAXSIZEHISTO - 1] = histovec[MAXSIZEHISTO - 1].saturating_add(1);
+            } else {
+                histovec[*tup.0 as usize - 1] = histovec[*tup.0 as usize - 1].saturating_add(1);
+            }
+        }
+
+        // Remove the last bin, as it might affect the fit, but we want it in the vector to plot it in case the coverage is really
+        // large (and so that we can detect it).
+        log::info!("Counting finished. Starting fit...");
+        let mut fit = SpectrumFitter::new();
+        let minc = fit.fit_histogram(histovec[..(MAXSIZEHISTO - 1)].to_vec()).expect("Fit to the k-mer spectrum failed!") as u16;
+
+        if minc <= 0 {
+            panic!("Fitted min_count value is zero or negative!");
+        }
+
+        log::info!("Fit done! Fitted min_count value: {}. Starting filtering...", minc);
+
+        countmap.retain(|h, tup| {
+            if tup.0 >= minc {
+                themap
+                    .entry(*h)
+                    .or_insert( RefCell::new(HashInfoSimple {
+                                hnc:    tup.1,
+                                b:      tup.2,
+                                pre:    Vec::new(),
+                                post:   Vec::new(),
+                                counts: tup.0,
+                        }) );
+            } else {
+                outdict.remove(h);
+                minmaxdict.remove(&tup.1);
+            }
+
+            false
+        });
+    } else {
+        minc = qual.min_count;
+
+        countmap.retain(|h, tup| {
+            if tup.0 >= minc {
+                themap
+                    .entry(*h)
+                    .or_insert( RefCell::new(HashInfoSimple {
+                                hnc:    tup.1,
+                                b:      tup.2,
+                                pre:    Vec::new(),
+                                post:   Vec::new(),
+                                counts: tup.0,
+                        }) );
+            } else {
+                outdict.remove(h);
+                minmaxdict.remove(&tup.1);
+            }
+
+            if tup.0 as usize > MAXSIZEHISTO {
+                histovec[MAXSIZEHISTO - 1] = histovec[MAXSIZEHISTO - 1].saturating_add(1);
+            } else {
+                histovec[tup.0 as usize - 1] = histovec[tup.0 as usize - 1].saturating_add(1);
+            }
+            false
+        });
+    }
+
+    outdict.shrink_to_fit();
+    minmaxdict.shrink_to_fit();
+
+    if out_path.is_some() {
+        // Plotting!
+        let backend = BitMapBackend::new(out_path.as_ref().unwrap().as_path(), (1280, 960));
+
+        let root = backend.into_drawing_area();
+
+        let _ = root.fill(&WHITE);
+
+        let mut chart = ChartBuilder::on(&root)
+            .x_label_area_size(35)
+            .y_label_area_size(40)
+            .margin(5)
+            // .caption("k-mer spectrum", ("sans-serif", 30.0))
+            .caption("k-mer spectrum", ("ibm-plex-sans", 30.0))
+            .build_cartesian_2d((0u32..(MAXSIZEHISTO as u32)).into_segmented(), 0u32..200000u32).unwrap();
+
+        chart
+            .configure_mesh()
+            .disable_x_mesh()
+            .bold_line_style(WHITE.mix(0.3))
+            .y_desc("Counts")
+            .x_desc("k-mer frequency")
+            // .axis_desc_style(("sans-serif", 15))
+            .axis_desc_style(("ibm-plex-sans", 15))
+            .draw().unwrap();
+
+        chart.draw_series(
+            Histogram::vertical(&chart)
+                .style(RED.filled())
+                .data(histovec.iter().enumerate().map(|(i, x)| (i as u32, *x))),
+        ).unwrap();
+
+
+
+        // TODO: I have spent too much time trying to draw a vertical line or a rectangle to show in the
+        //       histogram the fitted limit. Not more at least until I decide to lose more of my life.
+        // https://stackoverflow.com/questions/78776201/how-to-dynamically-use-plotter-segmentvalue
+
+        // backend.draw_rect(
+        //     (0i32, 200000i32),
+        //     (fitted_min_count as i32, 0i32),
+        //     &BLACK,
+        //     true,
+        // ).unwrap();
+
+        // let testnum = fitted_min_count as i32;
+        // let rectangle = Rectangle::new(
+        //     [(0, 200000), (5, 0)],
+        //     BLUE.mix(0.5).filled(),
+        // );
+        //
+        // chart.draw_series(std::iter::once(rectangle.into_dyn())).unwrap();
+
+        // chart.plotting_area().draw(&rectangle).unwrap();
+
+        // chart.draw_series(LineSeries::new(
+        //     [(0i32, 0i32), (fitted_min_count as i32, 200000i32)].iter(),
+        //     &BLUE,
+        // )).unwrap();
+
+        root.present().expect("Unable to write result to file. Does the output folder exist?");
+    }
+
+    (outdict, minmaxdict, themap)
+}
+
+
+#[cfg(not(feature = "wasm"))]
+fn get_map_with_counts(
     invec:      &Vec<(u64, u64, u8)>,
     min_count:  u16,
+    out_path:   &mut Option<PathBuf>,
 ) -> HashMap::<u64, RefCell<HashInfoSimple>, BuildHasherDefault<NoHashHasher<u64>>>
 {
     let mut outdict = HashMap::with_hasher(BuildHasherDefault::default());
 
+    let mut i = 0;
+    let mut c : u16 = 0;
+    let mut tmphash = invec[i].0;
+    // let mut tmpcounter = 0;
+
+    // I'm not sure if there is another way of avoiding the extra conditional checks for plotting (or perhaps the
+    // compiler is smart enough to write in assembly exactly what I am now writing here?) than to rewrite the function
+    // with a big "if" as it is here, to gain a bit of efficiency (not sure how much, but well).
+    if out_path.is_some() {
+        let mut plotvec : Vec<u16> = Vec::new(); // For plotting
+
+        while i < invec.len() {
+            if tmphash != invec[i].0 {
+                if c >= min_count {
+                    // tmpcounter += 1;
+                    outdict
+                        .entry(tmphash)
+                        .or_insert( RefCell::new(HashInfoSimple {
+                                    hnc:    invec[i - 1].1,
+                                    b:      invec[i - 1].2,
+                                    pre:    Vec::new(),
+                                    post:   Vec::new(),
+                                    counts: c,
+                            }) );
+                } else {
+                    plotvec.push(c);
+                }
+                tmphash = invec[i].0;
+                c = 1;
+            } else {
+                c = c.saturating_add(1);
+            }
+            i += 1;
+        }
+
+
+        if c >= min_count {
+            // tmpcounter += 1;
+            outdict
+                .entry(tmphash)
+                .or_insert( RefCell::new(HashInfoSimple {
+                            hnc:    invec[i - 1].1,
+                            b:      invec[i - 1].2,
+                            pre:    Vec::new(),
+                            post:   Vec::new(),
+                            counts: c,
+                    }) );
+        } else {
+            plotvec.push(c);
+        }
+        plotvec.shrink_to_fit();
+
+        // Plotting!
+
+        let root = BitMapBackend::new(out_path.as_ref().unwrap().as_path(), (1280, 960)).into_drawing_area();
+
+        let _ = root.fill(&WHITE);
+
+        let mut chart = ChartBuilder::on(&root)
+            .x_label_area_size(35)
+            .y_label_area_size(40)
+            .margin(5)
+            .caption("k-mer spectrum", ("sans-serif", 30.0))
+            .build_cartesian_2d((0u32..200u32).into_segmented(), 0u32..200000u32).unwrap();
+
+        chart
+            .configure_mesh()
+            .disable_x_mesh()
+            .bold_line_style(WHITE.mix(0.3))
+            .y_desc("Counts")
+            .x_desc("k-mer frequency")
+            .axis_desc_style(("sans-serif", 15))
+            .draw().unwrap();
+
+        chart.draw_series(
+            Histogram::vertical(&chart)
+                .style(RED.filled())
+                .data(plotvec.iter().map(|x: &u16| (*x as u32, 1)).chain(outdict.iter().map(|(_, x)| (x.borrow().counts as u32, 1)))),
+        ).unwrap();
+
+        root.present().expect("Unable to write result to file. Does the output folder exist?");
+
+    //     exit(1);
+
+        // log::debug!("Good kmers {}", tmpcounter);
+    } else {
+        // Here we don't need to check for plotting or anything
+        while i < invec.len() {
+            if tmphash != invec[i].0 {
+                if c >= min_count {
+                    // tmpcounter += 1;
+                    outdict
+                        .entry(tmphash)
+                        .or_insert( RefCell::new(HashInfoSimple {
+                                    hnc:    invec[i - 1].1,
+                                    b:      invec[i - 1].2,
+                                    pre:    Vec::new(),
+                                    post:   Vec::new(),
+                                    counts: c,
+                            }) );
+                }
+                tmphash = invec[i].0;
+                c = 1;
+            } else {
+                c = c.saturating_add(1);
+            }
+            i += 1;
+        }
+
+
+        if c >= min_count {
+            // tmpcounter += 1;
+            outdict
+                .entry(tmphash)
+                .or_insert( RefCell::new(HashInfoSimple {
+                            hnc:    invec[i - 1].1,
+                            b:      invec[i - 1].2,
+                            pre:    Vec::new(),
+                            post:   Vec::new(),
+                            counts: c,
+                    }) );
+        }
+    }
+    return outdict;
+}
+
+
+
+#[cfg(not(feature = "wasm"))]
+fn get_map_with_counts_and_fit(
+    invec:      &mut Vec<(u64, u64, u8)>,
+    out_path:   &mut Option<PathBuf>,
+) -> HashMap::<u64, RefCell<HashInfoSimple>, BuildHasherDefault<NoHashHasher<u64>>>
+{
+    let mut outdict = HashMap::with_hasher(BuildHasherDefault::default());
 
     let mut i = 0;
     let mut c : u16 = 0;
     let mut tmphash = invec[i].0;
-    let mut tmpcounter = 0;
+    // let mut tmpcounter = 0;
 
-    let mut plotvec : Vec<u16> = Vec::new(); // For plotting
+    // Here we don't have the same issue as with the pre-defined min_count setting.
+    let mut plotvec : Vec<u32> = vec![0 as u32; MAXSIZEHISTO]; // For plotting
+
+    // We need to construct the histogram as well
 
     while i < invec.len() {
         if tmphash != invec[i].0 {
-            if c >= min_count {
-                tmpcounter += 1;
-                outdict
-                    .entry(tmphash)
-                    .or_insert( RefCell::new(HashInfoSimple {
-                                hnc:    invec[i - 1].1,
-                                b:      invec[i - 1].2,
-                                pre:    Vec::new(),
-                                post:   Vec::new(),
-                                counts: c,
-                        }) );
+            // tmpcounter += 1;
+            outdict
+                .entry(tmphash)
+                .or_insert( RefCell::new(HashInfoSimple {
+                            hnc:    invec[i - 1].1,
+                            b:      invec[i - 1].2,
+                            pre:    Vec::new(),
+                            post:   Vec::new(),
+                            counts: c,
+                    }) );
+
+            if c as usize > MAXSIZEHISTO {
+                plotvec[MAXSIZEHISTO - 1] = plotvec[MAXSIZEHISTO - 1].saturating_add(1);
             } else {
-                plotvec.push(c);
+                plotvec[c as usize - 1] = plotvec[c as usize - 1].saturating_add(1);
             }
-//             else {
-//                 log::debug!("{}", c);
-//             }
-//             if i > 500 {
-//                 log::debug!("{:?}", outdict);
-//                 log::debug!("{} {} {}", tmphash, c, i);
-//                 exit(1);
-//             }
+
             tmphash = invec[i].0;
             c = 1;
+
         } else {
             c = c.saturating_add(1);
         }
@@ -724,61 +1098,118 @@ fn get_map_with_counts_with_hashes_only(
     }
 
 
-    if c >= min_count {
-        tmpcounter += 1;
-        outdict
-            .entry(tmphash)
-            .or_insert( RefCell::new(HashInfoSimple {
-                        hnc:    invec[i - 1].1,
-                        b:      invec[i - 1].2,
-                        pre:    Vec::new(),
-                        post:   Vec::new(),
-                        counts: c,
-                }) );
+    // tmpcounter += 1;
+    outdict
+        .entry(tmphash)
+        .or_insert( RefCell::new(HashInfoSimple {
+                    hnc:    invec[i - 1].1,
+                    b:      invec[i - 1].2,
+                    pre:    Vec::new(),
+                    post:   Vec::new(),
+                    counts: c,
+            }) );
+
+
+    if c as usize > MAXSIZEHISTO {
+        plotvec[MAXSIZEHISTO - 1] = plotvec[MAXSIZEHISTO - 1].saturating_add(1);
     } else {
-        plotvec.push(c);
+        plotvec[c as usize - 1] = plotvec[c as usize - 1].saturating_add(1);
     }
-    plotvec.shrink_to_fit();
 
-    // Plotting!
+    invec.clear(); invec.shrink_to_fit(); // Quick optimisation
 
-    let root = BitMapBackend::new("./draftrun/histogram.png", (1280, 960)).into_drawing_area();
+    // We need to do the fit!
+    log::info!("Counting finished. Starting fit...");
+    let mut fit = SpectrumFitter::new();
+    // Remove the last bin, as it might affect the fit, but we want it in the vector to plot it in case the coverage is really
+    // large (and so that we can detect it).
+    let fitted_min_count = fit.fit_histogram(plotvec[..(MAXSIZEHISTO - 1)].to_vec()).expect("Fit to the k-mer spectrum failed!") as u16;
 
-    let _ = root.fill(&WHITE);
+    if fitted_min_count <= 0 {
+        panic!("Fitted min_count value is zero or negative!");
+    }
 
-    let mut chart = ChartBuilder::on(&root)
-        .x_label_area_size(35)
-        .y_label_area_size(40)
-        .margin(5)
-        .caption("k-mer counts", ("sans-serif", 30.0))
-        .build_cartesian_2d((0u32..200u32).into_segmented(), 0u32..200000u32).unwrap();
+    log::info!("Fit done! Fitted min_count value: {}. Starting filtering...", fitted_min_count);
 
-    chart
-        .configure_mesh()
-        .disable_x_mesh()
-        .bold_line_style(WHITE.mix(0.3))
-        .y_desc("Number")
-        .x_desc("Count")
-        .axis_desc_style(("sans-serif", 15))
-        .draw().unwrap();
+    outdict.retain(|_, rc| {
+        rc.borrow().counts >= fitted_min_count
+    });
+    outdict.shrink_to_fit();
 
-    chart.draw_series(
-        Histogram::vertical(&chart)
-            .style(RED.filled())
-            .data(plotvec.iter().map(|x: &u16| (*x as u32, 1)).chain(outdict.iter().map(|(_, x)| (x.borrow().counts as u32, 1)))),
-    ).unwrap();
+    if out_path.is_some() {
+        // Plotting!
+        let backend = BitMapBackend::new(out_path.as_ref().unwrap().as_path(), (1280, 960));
 
-    root.present().expect("Unable to write result to file, please make sure 'images' dir exists under current dir");
+        let root = backend.into_drawing_area();
 
+        let _ = root.fill(&WHITE);
+
+        let mut chart = ChartBuilder::on(&root)
+            .x_label_area_size(35)
+            .y_label_area_size(40)
+            .margin(5)
+            // .caption("k-mer spectrum", ("sans-serif", 30.0))
+            .caption("k-mer spectrum", ("ibm-plex-sans", 30.0))
+            .build_cartesian_2d((0u32..(MAXSIZEHISTO as u32)).into_segmented(), 0u32..200000u32).unwrap();
+
+        chart
+            .configure_mesh()
+            .disable_x_mesh()
+            .bold_line_style(WHITE.mix(0.3))
+            .y_desc("Counts")
+            .x_desc("k-mer frequency")
+            // .axis_desc_style(("sans-serif", 15))
+            .axis_desc_style(("ibm-plex-sans", 15))
+            .draw().unwrap();
+
+        chart.draw_series(
+            Histogram::vertical(&chart)
+                .style(RED.filled())
+                .data(plotvec.iter().enumerate().map(|(i, x)| (i as u32, *x))),
+        ).unwrap();
+
+
+
+        // TODO: I have spent too much time trying to draw a vertical line or a rectangle to show in the
+        //       histogram the fitted limit. Not more at least until I decide to lose more of my life.
+        // https://stackoverflow.com/questions/78776201/how-to-dynamically-use-plotter-segmentvalue
+
+        // backend.draw_rect(
+        //     (0i32, 200000i32),
+        //     (fitted_min_count as i32, 0i32),
+        //     &BLACK,
+        //     true,
+        // ).unwrap();
+
+        // let testnum = fitted_min_count as i32;
+        // let rectangle = Rectangle::new(
+        //     [(0, 200000), (5, 0)],
+        //     BLUE.mix(0.5).filled(),
+        // );
+        //
+        // chart.draw_series(std::iter::once(rectangle.into_dyn())).unwrap();
+
+        // chart.plotting_area().draw(&rectangle).unwrap();
+
+        // chart.draw_series(LineSeries::new(
+        //     [(0i32, 0i32), (fitted_min_count as i32, 200000i32)].iter(),
+        //     &BLUE,
+        // )).unwrap();
+
+        root.present().expect("Unable to write result to file. Does the output folder exist?");
+    }
+
+
+    // log::debug!("Good kmers {}", tmpcounter);
 //     exit(1);
 
-    log::debug!("Good kmers {}", tmpcounter);
     outdict
 }
 
 
+
 #[cfg(feature = "wasm")]
-fn get_map_for_wasm(
+fn get_map_wasm(
     invec:      &Vec<(u64, u64, u8)>,
     min_count:  u16,
 ) -> (HashMap::<u64, RefCell<HashInfoSimple>, BuildHasherDefault<NoHashHasher<u64>>>, Vec<u32>)
@@ -789,14 +1220,14 @@ fn get_map_for_wasm(
     let mut i = 0;
     let mut c : u16 = 0;
     let mut tmphash = invec[i].0;
-    let mut tmpcounter = 0;
+    // let mut tmpcounter = 0;
 
     let mut plotvec : Vec<u32> = vec![0 as u32; MAXSIZEHISTO]; // For plotting
 
     while i < invec.len() {
         if tmphash != invec[i].0 {
             if c >= min_count {
-                tmpcounter += 1;
+                // tmpcounter += 1;
                 outdict
                     .entry(tmphash)
                     .or_insert( RefCell::new(HashInfoSimple {
@@ -824,7 +1255,7 @@ fn get_map_for_wasm(
 
 
     if c >= min_count {
-        tmpcounter += 1;
+        // tmpcounter += 1;
         outdict
             .entry(tmphash)
             .or_insert( RefCell::new(HashInfoSimple {
@@ -841,12 +1272,11 @@ fn get_map_for_wasm(
     } else {
         plotvec[c as usize - 1] = plotvec[c as usize - 1].saturating_add(1);
     }
-    // loG(format!("Good kmers {}", tmpcounter).as_str(), Some("debug"));
+    // logw(format!("Good kmers {}", tmpcounter).as_str(), Some("debug"));
     (outdict, plotvec)
 }
 
 
-#[cfg(feature = "wasm")]
 fn update_countmap(
     invec    : &    Vec<(u64, u64, u8)>,
     countmap : &mut HashMap::<u64, (u16, u64, u8), BuildHasherDefault<NoHashHasher<u64>>>,
@@ -855,7 +1285,7 @@ fn update_countmap(
     let mut i = 0;
     let mut c : u16 = 0;
     let mut tmphash = invec[i].0;
-    let mut tmpcounter = 0;
+    // let mut tmpcounter = 0;
 
 
     while i < invec.len() {
@@ -876,82 +1306,407 @@ fn update_countmap(
 }
 
 
+#[cfg(not(feature = "wasm"))]
+fn chunked_processing_standalone<IntT>(
+    file1:    &str,
+    file2:    &str,
+    k:        usize,
+    qual:     &QualOpts,
+    outvec:   &mut Vec<(u64, u64, u8)>,
+    csize:    usize,
+    do_fit:   bool,
+    out_path: &mut Option<PathBuf>,
+) -> (HashMap::<u64, IntT, BuildHasherDefault<NoHashHasher<u64>>>, HashMap::<u64, u64, BuildHasherDefault<NoHashHasher<u64>>>, HashMap::<u64, RefCell<HashInfoSimple>, BuildHasherDefault<NoHashHasher<u64>>>)
+where
+    IntT: for<'a> UInt<'a>,
+{
+    log::info!("Getting kmers from first file. Creating reader...");
+
+    let mut outdict    = HashMap::with_hasher(BuildHasherDefault::default());
+    let mut minmaxdict = HashMap::with_hasher(BuildHasherDefault::default());
+    let mut themap     = HashMap::with_hasher(BuildHasherDefault::default());
+    let mut countmap : HashMap::<u64, (u16, u64, u8), BuildHasherDefault<NoHashHasher<u64>>> = HashMap::with_hasher(BuildHasherDefault::default());
+
+    log::info!("Getting kmers from file {file1}. Creating reader...");
+    let mut reader =
+        parse_fastx_file(file1).unwrap_or_else(|_| panic!("Invalid path/file: {file1}"));
+
+    let mut histovec : Vec<u32> = vec![0; MAXSIZEHISTO];
+
+    log::info!("Entering while loop...");
+
+    let mut i_record = 0;
+
+    while let Some(record) = reader.next() {
+        let seqrec = record.expect("Invalid FASTQ record");
+        let rl = seqrec.seq().len();
+        let kmer_opt = Kmer::<IntT>::new(
+            seqrec.seq(),
+            rl,
+            seqrec.qual(),
+            k,
+            qual.min_qual,
+            true,
+        );
+        if let Some(mut kmer_it) = kmer_opt {
+            let (hc, hnc, b, km) = kmer_it.get_curr_kmerhash_and_bases_and_kmer();
+            outvec.push( (hc, hnc, b) );
+            outdict.entry(hc).or_insert(km);
+            minmaxdict.entry(hnc).or_insert(hc);
+            while let Some(tmptuple) = kmer_it.get_next_kmer_and_give_us_things() {
+                let (hc, hnc, b, km) = tmptuple;
+                outvec.push( (hc, hnc, b) );
+                outdict.entry(hc).or_insert(km);
+                minmaxdict.entry(hnc).or_insert(hc);
+            }
+        }
+
+        i_record += 1;
+        if i_record >= csize {
+            // Processssssss! And reset.
+            if !outvec.is_empty() {
+                log::info!("Processing chunk. Sorting k-mers...");
+                outvec.par_sort_unstable_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+                log::info!("k-mers sorted. Counting k-mers...");
+                // Then, do a counting of everything and save the results in a dictionary and return it
+
+                update_countmap(&outvec, &mut countmap);
+            }
+
+            // Reset
+            outvec.clear();
+            i_record = 0;
+        }
+
+    }
+    log::info!("Finished getting kmers from first file. Starting with the second...");
+
+    reader =
+        parse_fastx_file(file2).unwrap_or_else(|_| panic!("Invalid path/file: {file2}"));
+
+    // Filling the seq of the second file!
+    while let Some(record) = reader.next() {
+        let seqrec = record.expect("Invalid FASTQ record");
+        // put_these_nts_into_an_efficient_vector_rc(&seqrec.seq(), &mut theseq, (itrecord % 32) as u8);
+        let rl = seqrec.seq().len();
+        let kmer_opt = Kmer::<IntT>::new(
+            seqrec.seq(),
+            rl,
+            seqrec.qual(),
+            k,
+            qual.min_qual,
+            true,
+        );
+        if let Some(mut kmer_it) = kmer_opt {
+            let (hc, hnc, b, km) = kmer_it.get_curr_kmerhash_and_bases_and_kmer();
+            outvec.push( (hc, hnc, b) );
+            outdict.entry(hc).or_insert(km);
+            minmaxdict.entry(hnc).or_insert(hc);
+            while let Some(tmptuple) = kmer_it.get_next_kmer_and_give_us_things() {
+                let (hc, hnc, b, km) = tmptuple;
+                outvec.push( (hc, hnc, b) );
+                outdict.entry(hc).or_insert(km);
+                minmaxdict.entry(hnc).or_insert(hc);
+            }
+        }
+
+        i_record += 1;
+        if i_record >= csize {
+            // Processssssss! And reset.
+            if !outvec.is_empty() {
+                log::info!("Processing chunk. Sorting k-mers...");
+                outvec.par_sort_unstable_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+                log::info!("k-mers sorted. Counting k-mers...");
+                // Then, do a counting of everything and save the results in a dictionary and return it
+
+                update_countmap(&outvec, &mut countmap);
+            }
+
+            // Reset
+            outvec.clear();
+            i_record = 0;
+        }
+    }
+
+    if i_record > 0 {
+        // Processssssss! And reset.
+        if !outvec.is_empty() {
+            log::info!("Processing last chunk. Sorting k-mers...");
+            outvec.par_sort_unstable_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+            log::info!("k-mers sorted. Counting k-mers...");
+            // Then, do a counting of everything and save the results in a dictionary and return it
+
+            update_countmap(&outvec, &mut countmap);
+        }
+        // Reset
+        outvec.clear();
+    }
+    log::info!("Finished getting kmers from the second file");
+    log::info!("Filtering...");
+
+    // Now, get themap, histovec, and filter outdict and minmaxdict
+    countmap.shrink_to_fit();
+    let minc;
+
+    // This can be optimised. also better written: I had to repeat the code for the retains, to try to improve slightly the running time in
+    // case no autofitting is requested. In any case, it could be improved in the future.
+    if do_fit {
+        for tup in countmap.iter() {
+            if *tup.0 as usize > MAXSIZEHISTO {
+                histovec[MAXSIZEHISTO - 1] = histovec[MAXSIZEHISTO - 1].saturating_add(1);
+            } else {
+                histovec[*tup.0 as usize - 1] = histovec[*tup.0 as usize - 1].saturating_add(1);
+            }
+        }
+
+        // Remove the last bin, as it might affect the fit, but we want it in the vector to plot it in case the coverage is really
+        // large (and so that we can detect it).
+        log::info!("Counting finished. Starting fit...");
+        let mut fit = SpectrumFitter::new();
+        let minc = fit.fit_histogram(histovec[..(MAXSIZEHISTO - 1)].to_vec()).expect("Fit to the k-mer spectrum failed!") as u16;
+
+        if minc <= 0 {
+            panic!("Fitted min_count value is zero or negative!");
+        }
+
+        log::info!("Fit done! Fitted min_count value: {}. Starting filtering...", minc);
+
+        countmap.retain(|h, tup| {
+            if tup.0 >= minc {
+                themap
+                    .entry(*h)
+                    .or_insert( RefCell::new(HashInfoSimple {
+                                hnc:    tup.1,
+                                b:      tup.2,
+                                pre:    Vec::new(),
+                                post:   Vec::new(),
+                                counts: tup.0,
+                        }) );
+            } else {
+                outdict.remove(h);
+                minmaxdict.remove(&tup.1);
+            }
+
+            false
+        });
+    } else {
+        minc = qual.min_count;
+
+        countmap.retain(|h, tup| {
+            if tup.0 >= minc {
+                themap
+                    .entry(*h)
+                    .or_insert( RefCell::new(HashInfoSimple {
+                                hnc:    tup.1,
+                                b:      tup.2,
+                                pre:    Vec::new(),
+                                post:   Vec::new(),
+                                counts: tup.0,
+                        }) );
+            } else {
+                outdict.remove(h);
+                minmaxdict.remove(&tup.1);
+            }
+
+            if tup.0 as usize > MAXSIZEHISTO {
+                histovec[MAXSIZEHISTO - 1] = histovec[MAXSIZEHISTO - 1].saturating_add(1);
+            } else {
+                histovec[tup.0 as usize - 1] = histovec[tup.0 as usize - 1].saturating_add(1);
+            }
+            false
+        });
+    }
+
+    drop(countmap);
+    outdict.shrink_to_fit();
+    minmaxdict.shrink_to_fit();
+
+    if out_path.is_some() {
+        // Plotting!
+        let backend = BitMapBackend::new(out_path.as_ref().unwrap().as_path(), (1280, 960));
+
+        let root = backend.into_drawing_area();
+
+        let _ = root.fill(&WHITE);
+
+        let mut chart = ChartBuilder::on(&root)
+            .x_label_area_size(35)
+            .y_label_area_size(40)
+            .margin(5)
+            // .caption("k-mer spectrum", ("sans-serif", 30.0))
+            .caption("k-mer spectrum", ("ibm-plex-sans", 30.0))
+            .build_cartesian_2d((0u32..(MAXSIZEHISTO as u32)).into_segmented(), 0u32..200000u32).unwrap();
+
+        chart
+            .configure_mesh()
+            .disable_x_mesh()
+            .bold_line_style(WHITE.mix(0.3))
+            .y_desc("Counts")
+            .x_desc("k-mer frequency")
+            // .axis_desc_style(("sans-serif", 15))
+            .axis_desc_style(("ibm-plex-sans", 15))
+            .draw().unwrap();
+
+        chart.draw_series(
+            Histogram::vertical(&chart)
+                .style(RED.filled())
+                .data(histovec.iter().enumerate().map(|(i, x)| (i as u32, *x))),
+        ).unwrap();
+
+
+
+        // TODO: I have spent too much time trying to draw a vertical line or a rectangle to show in the
+        //       histogram the fitted limit. Not more at least until I decide to lose more of my life.
+        // https://stackoverflow.com/questions/78776201/how-to-dynamically-use-plotter-segmentvalue
+
+        // backend.draw_rect(
+        //     (0i32, 200000i32),
+        //     (fitted_min_count as i32, 0i32),
+        //     &BLACK,
+        //     true,
+        // ).unwrap();
+
+        // let testnum = fitted_min_count as i32;
+        // let rectangle = Rectangle::new(
+        //     [(0, 200000), (5, 0)],
+        //     BLUE.mix(0.5).filled(),
+        // );
+        //
+        // chart.draw_series(std::iter::once(rectangle.into_dyn())).unwrap();
+
+        // chart.plotting_area().draw(&rectangle).unwrap();
+
+        // chart.draw_series(LineSeries::new(
+        //     [(0i32, 0i32), (fitted_min_count as i32, 200000i32)].iter(),
+        //     &BLUE,
+        // )).unwrap();
+
+        root.present().expect("Unable to write result to file. Does the output folder exist?");
+    }
+
+    (outdict, minmaxdict, themap)
+}
+
+
 /// Read fastq files, get the reads, get the k-mers, count them, filter them by count, and get some way of recovering the sequence later.
 #[cfg(not(feature = "wasm"))]
-pub fn preprocessing_gpulike_with_dict_and_seq<IntT>(
+pub fn preprocessing_standalone<IntT>(
     input_files:    &[InputFastx],
     k:              usize,
     qual:           &QualOpts,
     timevec:        &mut Vec<Instant>,
+    out_path:       &mut Option<PathBuf>,
+    csize   :       usize,
+    do_bloom:       bool,
+    do_fit  :       bool,
 ) -> (HashMap::<u64, RefCell<HashInfoSimple>, BuildHasherDefault<NoHashHasher<u64>>>, Vec<u64>, HashMap::<u64, IntT, BuildHasherDefault<NoHashHasher<u64>>>, HashMap::<u64, u64, BuildHasherDefault<NoHashHasher<u64>>>)
 where
     IntT: for<'a> UInt<'a>,
 {
-    // Build indexes
-    log::info!("Starting preprocessing_gpulike with k = {k}");
+    log::info!("Starting preprocessing_standalone with k = {k}");
 
-    if any_fastq(input_files) {
-        log::info!("FASTQ files filtered with: {qual}");
+    if do_bloom {
+        // Build indexes
+        log::info!("Processing using a Bloom filter");
+
+        let (thedict, maxmindict, themap) = bloom_filter_preprocessing_standalone::<IntT>(
+            &input_files[0].1,
+            input_files[0].2.as_ref().expect("No paired reads!"),
+            k,
+            qual,
+            do_fit,
+            out_path,
+        );
+        return (themap, Vec::new(), thedict, maxmindict);
+
+    } else if csize <= 0 {
+        if any_fastq(input_files) {
+            log::info!("FASTQ files filtered with: {qual}");
+        } else {
+            panic!("Input files are not FASTQ");
+        }
+
+        let total_size  = input_files.len();
+        if total_size > 1 {panic!("Not expecting more than a pair of pair-end reads right now!");};
+
+
+        // First, we want to fill our mega-vector with all k-mers from both paired-end reads
+        log::info!("Filling vector");
+
+        let mut tmpvec : Vec<(u64, u64, u8)> = Vec::new();
+        let (theseq, thedict, maxmindict) = get_kmers_from_both_files_and_the_dict_and_the_seq::<IntT>(&input_files[0].1,
+            input_files[0].2.as_ref().expect("No paired reads!"),
+            k,
+            qual,
+            &mut tmpvec);
+
+        timevec.push(Instant::now());
+        log::info!("Kmers extracted in {} s", timevec.last().unwrap().duration_since(*timevec.get(timevec.len().wrapping_sub(2)).unwrap()).as_secs());
+
+
+        // Then, we want to sort it according to the hash
+        log::debug!("Number of kmers BEFORE cleaning: {:?}", tmpvec.len());
+        log::info!("Sorting vector");
+        tmpvec.par_sort_unstable_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+
+        timevec.push(Instant::now());
+        log::info!("Kmers sorted in {} s", timevec.last().unwrap().duration_since(*timevec.get(timevec.len().wrapping_sub(2)).unwrap()).as_secs());
+
+        // Then, do a counting of everything and save the results in a dictionary and return it
+        timevec.push(Instant::now());
+        log::info!("Counting k-mers");
+        let themap;
+
+        if !do_fit {
+            themap = get_map_with_counts(&mut tmpvec, qual.min_count, out_path);
+        } else {
+            themap = get_map_with_counts_and_fit(&mut tmpvec, out_path);
+        }
+        drop(tmpvec);
+
+        timevec.push(Instant::now());
+        log::info!("Kmers counted in {} s", timevec.last().unwrap().duration_since(*timevec.get(timevec.len().wrapping_sub(2)).unwrap()).as_secs());
+
+        return (themap, theseq, thedict, maxmindict)
     } else {
-        log::info!("All input files FASTA (no error filtering)");
+        // Build indexes
+        log::info!("Processing in chunks of size {} the input files", csize);
+
+        let mut tmpvec : Vec<(u64, u64, u8)> = Vec::new();
+        let (thedict, maxmindict, themap) = chunked_processing_standalone::<IntT>(
+            &input_files[0].1,
+            input_files[0].2.as_ref().expect("No paired reads!"),
+            k,
+            qual,
+            &mut tmpvec,
+            csize,
+            do_fit,
+            out_path,
+        );
+        drop(tmpvec);
+        return (themap, Vec::new(), thedict, maxmindict);
     }
 
-    let total_size  = input_files.len();
-    if total_size > 1 {panic!("Not expecting more than a pair of pair-end reads right now!");};
-
-
-    // First, we want to fill our mega-vector with all k-mers from both paired-end reads
-    log::info!("Filling vector");
-
-    let mut tmpvec : Vec<(u64, u64, u8)> = Vec::new();
-    let (theseq, thedict, maxmindict) = get_kmers_from_both_files_and_the_dict_and_the_seq::<IntT>(&input_files[0].1,
-        input_files[0].2.as_ref().expect("No paired reads!"),
-        k,
-        qual,
-        &mut tmpvec);
-
-    timevec.push(Instant::now());
-    log::info!("Kmers extracted in {} s", timevec.last().unwrap().duration_since(*timevec.get(timevec.len().wrapping_sub(2)).unwrap()).as_secs());
-
-
-    // Then, we want to sort it according to the hash
-    log::debug!("Number of kmers BEFORE cleaning: {:?}", tmpvec.len());
-    log::info!("Sorting vector");
-    tmpvec.par_sort_unstable_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
-
-    timevec.push(Instant::now());
-    log::info!("Kmers sorted in {} s", timevec.last().unwrap().duration_since(*timevec.get(timevec.len().wrapping_sub(2)).unwrap()).as_secs());
-
-
-    // Then, do a counting of everything and save the results in a dictionary and return it
-    timevec.push(Instant::now());
-    log::info!("Counting k-mers");
-    let themap = get_map_with_counts_with_hashes_only(&tmpvec, qual.min_count);
-    drop(tmpvec);
-
-    timevec.push(Instant::now());
-    log::info!("Kmers counted in {} s", timevec.last().unwrap().duration_since(*timevec.get(timevec.len().wrapping_sub(2)).unwrap()).as_secs());
-
-    (themap, theseq, thedict, maxmindict)
 }
 
 
 
 #[cfg(feature = "wasm")]
-pub fn preprocessing_for_wasm<IntT>(
+pub fn preprocessing_wasm<IntT>(
     file1   : &mut WebSysFile,
     file2   : &mut WebSysFile,
     k       : usize,
     qual    : &QualOpts,
     csize   : usize,
-    do_bloom : bool,
+    do_bloom: bool,
+    do_fit  : bool,
 ) -> (HashMap::<u64, RefCell<HashInfoSimple>, BuildHasherDefault<NoHashHasher<u64>>>, Option<HashMap::<u64, IntT, BuildHasherDefault<NoHashHasher<u64>>>>, HashMap::<u64, u64, BuildHasherDefault<NoHashHasher<u64>>>, Vec<u32>)
 where
     IntT: for<'a> UInt<'a>,
 {
     if do_bloom {
         // Build indexes
-        loG("Processing using a Bloom filter", Some("info"));
+        logw("Processing using a Bloom filter", Some("info"));
 
         let (thedict, maxmindict, themap, mut histovec) = bloom_filter_preprocessing_wasm::<IntT>(
             file1,
@@ -963,10 +1718,10 @@ where
 
     } else if csize <= 0 {
         // Build indexes
-        loG("Starting preprocessing with k = {k}", Some("info"));
+        logw("Starting preprocessing with k = {k}", Some("info"));
 
         // First, we want to fill our mega-vector with all k-mers from both paired-end reads
-        loG("Filling vector", Some("info"));
+        logw("Filling vector", Some("info"));
 
         let mut tmpvec : Vec<(u64, u64, u8)> = Vec::new();
         let (thedict, maxmindict) = get_kmers_from_both_files_wasm::<IntT>(file1,
@@ -976,29 +1731,29 @@ where
                                                                            &mut tmpvec
         );
 
-        loG("Kmers extracted", Some("info"));
+        logw("Kmers extracted", Some("info"));
 
 
         // Then, we want to sort it according to the hash
         // log::debug!("Number of kmers BEFORE cleaning: {:?}", tmpvec.len());
-        loG("Sorting vector", Some("info"));
+        logw("Sorting vector", Some("info"));
         tmpvec.par_sort_unstable_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
 
-        loG("Kmers sorted.", Some("info"));
+        logw("Kmers sorted.", Some("info"));
 
 
         // Then, do a counting of everything and save the results in a dictionary and return it
-        loG("Counting k-mers", Some("info"));
-        let (themap, mut histovec) = get_map_for_wasm(&tmpvec, qual.min_count);
+        logw("Counting k-mers", Some("info"));
+        let (themap, mut histovec) = get_map_wasm(&tmpvec, qual.min_count);
         histovec.shrink_to_fit();
         drop(tmpvec);
 
-        loG("Kmers counted.", Some("info"));
+        logw("Kmers counted.", Some("info"));
 
         return (themap, Some(thedict), maxmindict, histovec);
     } else {
         // Build indexes
-        loG(format!("Processing in chunks of size {} the input files", csize).as_str(), Some("info"));
+        logw(format!("Processing in chunks of size {} the input files", csize).as_str(), Some("info"));
 
         let mut tmpvec : Vec<(u64, u64, u8)> = Vec::new();
         let (thedict, maxmindict, themap, mut histovec) = chunked_processing_wasm::<IntT>(

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -540,11 +540,11 @@ where
     // This can be optimised. also better written: I had to repeat the code for the retains, to try to improve slightly the running time in
     // case no autofitting is requested. In any case, it could be improved in the future.
     if do_fit {
-        for tup in countmap.iter() {
-            if *tup.0 as usize > MAXSIZEHISTO {
+        for (_, tup) in countmap.iter() {
+            if tup.0 as usize > MAXSIZEHISTO {
                 histovec[MAXSIZEHISTO - 1] = histovec[MAXSIZEHISTO - 1].saturating_add(1);
             } else {
-                histovec[*tup.0 as usize - 1] = histovec[*tup.0 as usize - 1].saturating_add(1);
+                histovec[tup.0 as usize - 1] = histovec[tup.0 as usize - 1].saturating_add(1);
             }
         }
 
@@ -743,11 +743,11 @@ where
     // case no autofitting is requested. In any case, it could be improved in the future.
     let mut minc = qual.min_count;
     if do_fit {
-        for tup in countmap.iter() {
-            if *tup.0 as usize > MAXSIZEHISTO {
+        for (_, tup) in countmap.iter() {
+            if tup.0 as usize > MAXSIZEHISTO {
                 histovec[MAXSIZEHISTO - 1] = histovec[MAXSIZEHISTO - 1].saturating_add(1);
             } else {
-                histovec[*tup.0 as usize - 1] = histovec[*tup.0 as usize - 1].saturating_add(1);
+                histovec[tup.0 as usize - 1] = histovec[tup.0 as usize - 1].saturating_add(1);
             }
         }
 
@@ -916,11 +916,11 @@ where
     // This can be optimised. also better written: I had to repeat the code for the retains, to try to improve slightly the running time in
     // case no autofitting is requested. In any case, it could be improved in the future.
     if do_fit {
-        for tup in countmap.iter() {
-            if *tup.0 as usize > MAXSIZEHISTO {
+        for (_, tup) in countmap.iter() {
+            if tup.0 as usize > MAXSIZEHISTO {
                 histovec[MAXSIZEHISTO - 1] = histovec[MAXSIZEHISTO - 1].saturating_add(1);
             } else {
-                histovec[*tup.0 as usize - 1] = histovec[*tup.0 as usize - 1].saturating_add(1);
+                histovec[tup.0 as usize - 1] = histovec[tup.0 as usize - 1].saturating_add(1);
             }
         }
 
@@ -1501,8 +1501,9 @@ fn update_countmap(
     while i < invec.len() {
         if tmphash != invec[i].0 {
 
-            let tmpref = countmap.entry(tmphash).or_insert( (c, invec[i - 1].1, invec[i - 1].2) );
+            let tmpref = countmap.entry(tmphash).or_insert( (0, invec[i - 1].1, invec[i - 1].2) );
             tmpref.0 = tmpref.0.saturating_add(c);
+
             tmphash = invec[i].0;
             c = 1;
         } else {
@@ -1511,7 +1512,7 @@ fn update_countmap(
         i += 1;
     }
 
-    let tmpref = countmap.entry(tmphash).or_insert( (c, invec[i - 1].1, invec[i - 1].2) );
+    let tmpref = countmap.entry(tmphash).or_insert( (0, invec[i - 1].1, invec[i - 1].2) );
     tmpref.0 = tmpref.0.saturating_add(c);
 }
 
@@ -1661,19 +1662,19 @@ where
     // This can be optimised. also better written: I had to repeat the code for the retains, to try to improve slightly the running time in
     // case no autofitting is requested. In any case, it could be improved in the future.
     if do_fit {
-        for tup in countmap.iter() {
-            if *tup.0 as usize > MAXSIZEHISTO {
+        for (_, tup) in countmap.iter() {
+            if tup.0 as usize > MAXSIZEHISTO {
                 histovec[MAXSIZEHISTO - 1] = histovec[MAXSIZEHISTO - 1].saturating_add(1);
             } else {
-                histovec[*tup.0 as usize - 1] = histovec[*tup.0 as usize - 1].saturating_add(1);
+                histovec[tup.0 as usize - 1] = histovec[tup.0 as usize - 1].saturating_add(1);
             }
         }
-
         // Remove the last bin, as it might affect the fit, but we want it in the vector to plot it in case the coverage is really
         // large (and so that we can detect it).
         log::info!("Counting finished. Starting fit...");
         let mut fit = SpectrumFitter::new();
-        let minc = fit.fit_histogram(histovec[..(MAXSIZEHISTO - 1)].to_vec()).expect("Fit to the k-mer spectrum failed!") as u16;
+        let minc = fit.fit_histogram(histovec.clone()[..(MAXSIZEHISTO - 1)].to_vec()).expect("Fit to the k-mer spectrum failed!") as u16;
+
 
         if minc <= 0 {
             panic!("Fitted min_count value is zero or negative!");

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -1850,7 +1850,7 @@ where
             qual,
             &mut tmpvec);
 
-        timevec.push(Instant::now());
+        // timevec.push(Instant::now());
         log::info!("Kmers extracted in {} s", timevec.last().unwrap().duration_since(*timevec.get(timevec.len().wrapping_sub(2)).unwrap()).as_secs());
 
 
@@ -1859,11 +1859,11 @@ where
         log::info!("Sorting vector");
         tmpvec.par_sort_unstable_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
 
-        timevec.push(Instant::now());
+        // timevec.push(Instant::now());
         log::info!("Kmers sorted in {} s", timevec.last().unwrap().duration_since(*timevec.get(timevec.len().wrapping_sub(2)).unwrap()).as_secs());
 
         // Then, do a counting of everything and save the results in a dictionary and return it
-        timevec.push(Instant::now());
+        // timevec.push(Instant::now());
         log::info!("Counting k-mers");
         let themap;
 
@@ -1874,7 +1874,7 @@ where
         }
         drop(tmpvec);
 
-        timevec.push(Instant::now());
+        // timevec.push(Instant::now());
         log::info!("Kmers counted in {} s", timevec.last().unwrap().duration_since(*timevec.get(timevec.len().wrapping_sub(2)).unwrap()).as_secs());
 
         return (themap, theseq, thedict, maxmindict)

--- a/src/save_functions.rs
+++ b/src/save_functions.rs
@@ -2,14 +2,14 @@
 
 use core::panic;
 use nohash_hasher::NoHashHasher;
-use std::{collections::HashMap, hash::BuildHasherDefault};
+use std::{collections::HashMap, hash::BuildHasherDefault, path::PathBuf};
 
 use super::io_utils::*;
 // use std::process::exit;
 
-use crate::bit_encoding::{UInt, decode_base};
+use crate::bit_encoding::UInt;
 use crate::graph_works::Contigs;
-use crate::loG;
+use crate::logw;
 
 
 /// Writes the contig sequences and hopefully their average counts/coverage in the future
@@ -106,7 +106,8 @@ where
         }
 
     }
-    log::debug!("\nNUMBER OF BAD THINGS: {}\n", counter);
+
+    logw(format!("\nNUMBER OF BAD THINGS: {}\n", counter).as_str(), Some("debug"));
 
 }
 
@@ -116,16 +117,16 @@ where
 pub fn save_as_fasta<IntT>(ingraph: &mut Contigs,
                                             inmap:   &    HashMap::<u64, IntT, BuildHasherDefault<NoHashHasher<u64>>>,
                                             k:        usize,
-                                            outfile: &String)
+                                            outfile: PathBuf)
 where
     IntT: for<'a> UInt<'a>, {
     // First, we write the sequences and the coverages
     write_sequences_and_coverages(ingraph, inmap, k);
 
     log::debug!("Starting to save");
-    log::debug!("{}", outfile);
+    log::debug!("{:?}", outfile);
     // Now, we just write all the contigs. We get our writing buffer with this:
-    let mut wbuf = set_ostream(&Some(outfile.clone()));
+    let mut wbuf = set_ostream(&Some(outfile.into_os_string().into_string().unwrap()));
     // And simply, contig per contig, we write the file
 
     log::debug!("\tLen.\tMean\tSD\tMedian");
@@ -135,17 +136,17 @@ where
 
 /// Stores all the contigs in fasta format, but exports it as JSON for javascript
 #[cfg(feature = "wasm")]
-pub fn save_as_fasta_for_wasm<IntT>(ingraph: &mut Contigs,
+pub fn save_as_fasta_wasm<IntT>(ingraph: &mut Contigs,
                                     inmap:   &    HashMap::<u64, IntT, BuildHasherDefault<NoHashHasher<u64>>>,
                                     k:        usize) -> String
 where
     IntT: for<'a> UInt<'a>, {
     // First, we write the sequences and the coverages
-    loG("Preparing to export contigs...", Some("info"));
+    logw("Preparing to export contigs...", Some("info"));
 
     write_sequences_and_coverages(ingraph, inmap, k);
 
-    loG("Saving in FASTA format as a JSON", Some("info"));
+    logw("Saving in FASTA format as a JSON", Some("info"));
     // Now, we just write all the contigs. We get our writing buffer with this:
     let mut out = "".to_string();
     let mut tmpvec : Vec<u8> = Vec::with_capacity(80);

--- a/src/save_functions.rs
+++ b/src/save_functions.rs
@@ -2,8 +2,12 @@
 
 use core::panic;
 use nohash_hasher::NoHashHasher;
-use std::{collections::HashMap, hash::BuildHasherDefault, path::PathBuf};
+use std::{collections::HashMap, hash::BuildHasherDefault};
 
+#[cfg(not(feature = "wasm"))]
+use std::path::PathBuf;
+
+#[cfg(not(feature = "wasm"))]
 use super::io_utils::*;
 // use std::process::exit;
 

--- a/src/spectrum_fitter.rs
+++ b/src/spectrum_fitter.rs
@@ -22,8 +22,11 @@ use argmin::solver::quasinewton::BFGS;
 
 use libm::lgamma;
 
+use log;
+use crate::logw;
 
-const MAX_COUNT : usize = 500;
+
+// const MAX_COUNT : usize = 500;
 const MIN_FREQ  : u32   = 50;
 const INIT_W0   : f64   = 0.8f64;
 const INIT_C    : f64   = 20.0f64;
@@ -36,16 +39,12 @@ const INIT_C    : f64   = 20.0f64;
 /// extract a table of the output for plotting purposes.
 #[derive(Default, Debug)]
 pub struct SpectrumFitter {
-    /// K-mer size
-    k: usize,
     /// Estimated error weight
     w0: f64,
     /// Estimated coverage
     c: f64,
     /// Coverage cutoff
     cutoff: usize,
-    /// Show logging
-    verbose: bool,
     /// Has the fit been run
     fitted: bool,
 }
@@ -53,19 +52,11 @@ pub struct SpectrumFitter {
 
 impl SpectrumFitter {
     /// Count split k-mers from a pair of input FASTQ files.
-    ///
-    /// `verbose` will also print to stderr on each iteration of the optiser.
-    pub fn new(k: usize, verbose: bool) -> Self {
-        if !(3..=256).contains(&k) || k % 2 == 0 {
-            panic!("Invalid k-mer length");
-        }
-
-        let mut cov_counts = Self {
-            k,
+    pub fn new() -> Self {
+        let cov_counts = Self {
             w0     : INIT_W0,
             c      : INIT_C,
             cutoff : 0,
-            verbose,
             fitted : false,
         };
 
@@ -100,7 +91,7 @@ impl SpectrumFitter {
 
         // Fit with maximum likelihood. Using BFGS optimiser and simple line search
         // seems to work fine
-        log::info!("Fitting Poisson mixture model using maximum likelihood");
+        logw("Fitting Poisson mixture model using maximum likelihood", Some("info"));
         let mixture_fit = MixPoisson { counts: counts_f64 };
         let init_param: Vec<f64> = vec![self.w0, self.c];
 
@@ -118,14 +109,14 @@ impl SpectrumFitter {
                 .max_iters(20)
         });
 
-        if self.verbose {
+        if log::log_enabled!(log::Level::Debug) {
             exec = exec.add_observer(SlogLogger::term(), ObserverMode::Always);
         }
 
         let res = exec.run()?;
 
         // Print diagnostics
-        log::info!("{res}");
+        logw(format!("{res}").as_str(), Some("info"));
         if let Some(termination_reason) = res.state().get_termination_reason() {
             if *termination_reason == SolverConverged {
                 // Best parameter vector

--- a/src/spectrum_fitter.rs
+++ b/src/spectrum_fitter.rs
@@ -11,15 +11,26 @@
 
 use core::panic;
 
-use argmin::core::observers::{ObserverMode, SlogLogger};
-use argmin::core::{
-    CostFunction, Error, Executor, Gradient, State, TerminationReason::SolverConverged,
+use argmin::{
+    core::{
+        // observers::{ObserverMode, SlogLogger},
+        observers::ObserverMode,
+        CostFunction,
+        Error,
+        Executor,
+        Gradient,
+        State,
+        TerminationReason::SolverConverged,
+    },
+    solver::{
+        linesearch::{
+            condition::ArmijoCondition,
+            BacktrackingLineSearch,
+        },
+        quasinewton::BFGS,
+    },
 };
-
-use argmin::solver::linesearch::condition::ArmijoCondition;
-use argmin::solver::linesearch::BacktrackingLineSearch;
-use argmin::solver::quasinewton::BFGS;
-
+use argmin_observer_slog::SlogLogger;
 use libm::lgamma;
 
 use log;


### PR DESCRIPTION
Various bug corrections included, documentation expanded, fixed in readme the download of version.

Standalone and wasm now have the same extra features (usage of Bloom filter, chunking, automatic minimum k-mer counts setting).

Harmonised output filenames, added prefix option, and also output dir folder.

Graph exportations and drawing of the k-mer frequency histogram are now optional and can be avoided.

Fixes/closes #4, #6, #10, and #14.