### PR TITLE
Lock xz2 and zstd behind features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,11 @@ repository = "https://github.com/bacpop/sparrowhawk-asm"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[features]
+default = ["xz2", "zstd"]
+xz2 = ["needletail/xz2"]
+zstd = ["needletail/zstd"]
+
 [dependencies]
 serde = { version = "1.0.219", features = ["derive"] }
 ahash = { version = "=0.8.11" }
@@ -30,7 +35,7 @@ argmin-observer-slog = { version = "0.1.0" }
 libm = { version = "0.2" }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-needletail = { version = "0.6.3", default-features = false, features = ["flate2", "xz2", "zstd"] }
+needletail = { version = "0.6.3", default-features = false, features = ["flate2"] }
 indicatif = { version = "0.17.11", features = ["rayon"] }
 plotters = { version = "0.3.7", features = ["ab_glyph"] }
 fern = { version = "0.7.1" }


### PR DESCRIPTION
Adds a feature to toggle xz2 and zstd compression for needletail -- these can fail to compile on some systems because they rely on C libraries. Flate2 does not have this problem because the default backend is a rewrite in rust. If sparrowhawk is used as a dependency, the current implementation always brings in xz2 and zstd and doesn't allow disabling them.

Default is to enable both which matches what the main branch is currently doing.